### PR TITLE
Production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 *.csv
 
 # logs outputs
+logs/*
 logs/eval/runs/*
 logs/train/runs/*
 logs/train/multiruns/*

--- a/configs/experiment/production.yaml
+++ b/configs/experiment/production.yaml
@@ -1,0 +1,26 @@
+# @package _global_
+
+# to execute this experiment run:
+# python src/train.py experiment=production
+# python src/predict.py experiment=production
+
+defaults:
+  - override /data: defile
+  - override /model: unet
+  - override /callbacks: default
+  - override /trainer: default
+
+# all parameters below will be merged with parameters from default configurations set above
+# this allows you to overwrite only specified parameters
+
+hydra:
+  sweeper:
+    params:
+      data:
+        species: ["Buse variable", "Milan royal"]
+
+paths:
+  output_dir: 'prod/${task_name}/${data.species.replace(" ", "_")}'
+
+predict:
+  ckpt_path: ${paths.output_dir}/checkpoints/last.ckpt

--- a/configs/extras/default.yaml
+++ b/configs/extras/default.yaml
@@ -2,7 +2,7 @@
 ignore_warnings: False
 
 # ask user for tags if none are provided in the config
-enforce_tags: True
+enforce_tags: False
 
 # pretty print config tree at the start of the run using Rich library
 print_config: True

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -13,7 +13,7 @@ defaults:
 
 task_name: "predict"
 
-tags: ["dev"]
+# tags: ["dev"]
 
 # passing checkpoint path is necessary for evaluation
-ckpt_path: ${paths.log_dir}/train/multiruns/2024-09-11_14-58-53/14/checkpoints/epoch_032.ckpt
+ckpt_path: ${paths.log_dir}/train/runs/2024-09-13_22-49-55/checkpoints/epoch_031.ckpt

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -30,7 +30,7 @@ task_name: "train"
 # tags to help you identify your experiments
 # you can overwrite this in experiment configs
 # overwrite from command line with `python train.py tags="[first_tag, second_tag]"`
-tags: ["dev"]
+# tags: ["dev"]
 
 # set False to skip model training
 train: True

--- a/src/train.py
+++ b/src/train.py
@@ -101,7 +101,7 @@ def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         log.info(f"Best ckpt path: {ckpt_path}")
 
         log.info("Export predictions!")
-        export.save(test_dataset=datamodule.data_test, test_pred=model.test_pred)
+        export.save_test(test_dataset=datamodule.data_test, test_pred=model.test_pred)
 
     test_metrics = trainer.callback_metrics
 


### PR DESCRIPTION
What do you think of using experiments to run the production model?
```bash
python src/train.py experiment=production
``` 
and run this on a github action

```bash
python src/predict.py experiment=production
```

Suggestion for production data structure:

```
prod/
├─ train/
│   ├─ buse_variable/
│   │  ├─ ... 
│   │  └─checkpoints
│   │     └─ last.cpkt
│   └─ milan royal
│      ├─ ...
│      └─checkpoints
│         └─ last.cpkt
└─ predict/
   ├─ buse_variable/
    │  ├─ 20240913_0600_predict.nc
    │  ├─ ...
    │  └─ 20240915_0600_predict.nc
    └─ milan royal/
       ├─ 20240913_0600_predict.nc
       ├─ ...
       └─20240915_0600_predict.nc
```

`prod/` would be at the root of the project. What do you think of this idea? 

---

Can we use automatically compute number of features in `config/model/default.yaml`
```yml
 nb_input_features_daily: ${len:data.era5_daily_locations * (len:data.era5_daily_variables+2)}
 ```
Or something like that? I'm not sure of the computation... is `lag_days` also needs to be accounted for here?


---
Suggest to change the default to Bussard des roseaux as Buse variable are not really migrating yet (https://www.trektellen.org/species/graph/3/2422/101/0?g=&l=&k=&jaar2=&jaar3=&graphtype1=bar&graphtype2=line&graphtype3=line&hidempbars=1&). `Épervier d'Europe` would be another good one to try in the few weeks. 

Here is the full list of raptor worth modeling: 
```yml
[
            "Buse variable",
            "Milan royal",
            "Milan noir",
            "Bondrée apivore",
            "Busard des roseaux",
            "Épervier d'Europe",
            "Faucon crécerelle",
            "Balbuzard pêcheur",
            "Faucon hobereau",
            #"Busard Saint-Martin",
            #"Faucon émerillon",
          ]
```
--- 
Remove tags: I don't think we are using them, so maybe we can remove them?