### PR TITLE
Fix log_transform: apply the logarithm and use the right parameters

### DIFF
--- a/src/data/data_transformer.py
+++ b/src/data/data_transformer.py
@@ -29,20 +29,27 @@ class Transformer:
     def __repr__(self):
         return f"Transformer(type:{self.type}, params:{self.params})"
 
+    # Minimum value used to clip data before taking the logarithm. Must be identical in
+    # `compute_param` and `apply`, otherwise fitted and applied transforms disagree.
+    LOG_CLIP_MIN = 1e-9
+
     def compute_param(self, data):
         if self.type == "standardization":
+            # params = (mean, std) of the raw data
             mean = data.mean().item()
             std = data.std().item()
             self.params = mean, std
 
         elif self.type == "log_transform":
-            clipped_data = data.clip(min=1e-9)  # Ensure no non-positive values
+            # params = (mean, std) of log(data), NOT (min, max)
+            clipped_data = data.clip(min=self.LOG_CLIP_MIN)  # Ensure no non-positive values
             log_data = np.log(clipped_data)
             mean = log_data.mean().item()
             std = log_data.std().item()
             self.params = mean, std
 
         elif self.type == "minmax_normalization":
+            # params = (min, max) of the raw data
             data_min = data.min().item()
             data_max = data.max().item()
             self.params = data_min, data_max
@@ -53,8 +60,11 @@ class Transformer:
             return (data - mean) / std
 
         elif self.type == "log_transform":
-            data_min, data_max = self.params
-            return (data - data_min) / (data_max - data_min)
+            # Take the log first, then standardise using the mean/std of the log-data
+            # computed in `compute_param`.
+            log_mean, log_std = self.params
+            log_data = np.log(data.clip(min=self.LOG_CLIP_MIN))
+            return (log_data - log_mean) / log_std
 
         elif self.type == "minmax_normalization":
             data_min, data_max = self.params


### PR DESCRIPTION
`Transformer.compute_param` stores the mean and std of log(data) for the
`log_transform` type, but `apply` unpacked that tuple as (data_min, data_max)
and computed a min-max style rescaling with no logarithm at all.

This transform is assigned to `total_precipitation` and
`instantaneous_10m_wind_gust`. Because most hourly precipitation values are
zero and get clipped to 1e-9, mean(log) is about -19 and std(log) about 4.5, so
the applied transform reduced to roughly (x + 19) / 23 for x in [0, 0.005] m.
The entire realistic precipitation range was therefore mapped onto a span of
0.0002 -- every value landed within a rounding error of 0.809. Precipitation and
wind gusts were, in effect, constant inputs: the model could not see rain.

After the fix the same synthetic ERA5-like precipitation series transforms to
mean 0, std 1, with a spread of about 3.4.

Also pulls the clip threshold into a named constant so that `compute_param` and
`apply` cannot drift apart again, and documents what `params` holds for each
transform type.

Note: the parameters already stored in data/transform_data.pickle remain valid
(compute_param was always correct), but models in prod/models/ were trained
against the broken transform and must be retrained before this is deployed.
