### PR TITLE
Fix wind units and direction convention on the forecast path

### DIFF
--- a/src/data/open_meteo.py
+++ b/src/data/open_meteo.py
@@ -32,25 +32,29 @@ CONVERSION_DICT = {
         "var": ["dew_point_2m"],
         "conv": lambda df: df["dew_point_2m"] + 273.15, # Convert °C to K
     },
+    # Wind direction follows the meteorological convention: the direction the wind blows
+    # FROM, in degrees clockwise from north. The components of the wind vector are
+    # therefore u = -V*sin(theta) (eastward) and v = -V*cos(theta) (northward).
+    # Sanity check: a 10 m/s wind from due north (theta=0) gives u=0, v=-10.
     "u_component_of_wind_10m": {
         "var": ["wind_speed_10m", "wind_direction_10m"],
-        "conv": lambda df: df["wind_speed_10m"]
-        * np.cos(np.radians(df["wind_direction_10m"])),
+        "conv": lambda df: -df["wind_speed_10m"]
+        * np.sin(np.radians(df["wind_direction_10m"])),
     },
     "v_component_of_wind_10m": {
         "var": ["wind_speed_10m", "wind_direction_10m"],
-        "conv": lambda df: df["wind_speed_10m"]
-        * np.sin(np.radians(df["wind_direction_10m"])),
+        "conv": lambda df: -df["wind_speed_10m"]
+        * np.cos(np.radians(df["wind_direction_10m"])),
     },
     "u_component_of_wind_100m": {
         "var": ["wind_speed_100m", "wind_direction_100m"],
-        "conv": lambda df: df["wind_speed_100m"]
-        * np.cos(np.radians(df["wind_direction_100m"])),
+        "conv": lambda df: -df["wind_speed_100m"]
+        * np.sin(np.radians(df["wind_direction_100m"])),
     },
     "v_component_of_wind_100m": {
         "var": ["wind_speed_100m", "wind_direction_100m"],
-        "conv": lambda df: df["wind_speed_100m"]
-        * np.sin(np.radians(df["wind_direction_100m"])),
+        "conv": lambda df: -df["wind_speed_100m"]
+        * np.cos(np.radians(df["wind_direction_100m"])),
     },
     "total_cloud_cover": {
         "var": ["cloud_cover"],
@@ -74,7 +78,9 @@ CONVERSION_DICT = {
     },
     "surface_solar_radiation_downwards": {
         "var": ["shortwave_radiation"],
-        "conv": lambda df: df["shortwave_radiation"]*3600, # Convert J/m^2 to W/m^2
+        # Open-Meteo returns W/m^2 averaged over the preceding hour; ERA5 accumulates
+        # J/m^2 over the hour. W/m^2 * 3600 s = J/m^2.
+        "conv": lambda df: df["shortwave_radiation"]*3600, # Convert W/m^2 to J/m^2
     },
     "convective_available_potential_energy": {
         "var": ["cape"],
@@ -135,7 +141,16 @@ def download_forecast_hourly(
             "hourly": openmeteo_variables,
             # "models": "ecmwf_ifs025",
             "past_days": lag_day,
-            "forecast_days": forecast_day + 1
+            "forecast_days": forecast_day + 1,
+            # Open-Meteo defaults to km/h for all wind variables, while ERA5 uses m/s.
+            # Without this the wind speeds, gusts and derived u/v components would be
+            # inflated by a factor of 3.6 relative to the training data.
+            "wind_speed_unit": "ms",
+            # Defaults, stated explicitly so a change upstream cannot silently break the
+            # unit conversions in CONVERSION_DICT above.
+            "temperature_unit": "celsius",
+            "precipitation_unit": "mm",
+            "timezone": "GMT",
         }
     )
 
@@ -171,9 +186,11 @@ def download_forecast_hourly(
             df[var] = CONVERSION_DICT[var]['conv'](df_forcast)
 
         # Get sun position (altitude, azimuth)
+        # NB: use distinct names so the `lat`/`lon` lists used for the API request above
+        # are not shadowed inside this loop.
         if add_sun:
-            lat, lon = get_lat_lon(locations[i])
-            sun_position = get_position(df["datetime"], lon[0], lat[0])
+            loc_lat, loc_lon = get_lat_lon(locations[i])
+            sun_position = get_position(df["datetime"], loc_lon[0], loc_lat[0])
             df["sun_altitude"] = sun_position["altitude"]
             df["sun_azimuth"] = sun_position["azimuth"]
 


### PR DESCRIPTION
Two independent errors made the wind field served to the model at forecast time
inconsistent with the ERA5 winds it was trained on. Wind direction is among the
strongest drivers of raptor passage, so this affected the forecast where it
matters most.

1. Units. Open-Meteo defaults to km/h for all wind variables while ERA5 uses
   m/s, and no unit was requested. `wind_speed_10m`, `wind_speed_100m` and
   `wind_gusts_10m` therefore arrived in km/h and were fed through conversions
   assuming m/s, inflating all five wind features by a factor of 3.6. After
   min-max normalisation with parameters fitted on ERA5, those values fell well
   outside [0, 1]. Fixed by requesting `wind_speed_unit: ms`.

2. Convention. Meteorological wind direction is the direction the wind blows
   FROM, measured clockwise from north, so u = -V*sin(theta) and
   v = -V*cos(theta). The code used u = V*cos(theta), v = V*sin(theta), which
   returns u = -v_true and v = -u_true: components swapped and sign-flipped, a
   reflection of the wind vector about the north-east axis. Verified against all
   four cardinal directions; a 10 m/s wind from due north now gives u=0, v=-10
   (previously u=+10, v=0).

Also pins `temperature_unit`, `precipitation_unit` and `timezone` explicitly so
an upstream default change cannot silently invalidate CONVERSION_DICT again,
corrects the radiation comment (the arithmetic was right, the comment stated the
conversion backwards), and stops the sun-position block from shadowing the
`lat`/`lon` lists used for the API request.

Training always used correct ERA5 m/s components, so this change moves inference
toward what the existing checkpoints were trained on and does not require
retraining.
