### PR TITLE
Restrict era5_daily_locations to the hourly-ERA5-backed locations

### DIFF
--- a/configs/data/defile.yaml
+++ b/configs/data/defile.yaml
@@ -47,14 +47,20 @@ era5_hourly_variables:
   - "total_cloud_cover"
   - "surface_solar_radiation_downwards"
 
+# Only locations backed by hourly ERA5 CSVs are listed here, so that the daily
+# aggregation below (a 24-hour mean) means the same thing for every location, and matches
+# what `download_forecast_daily` computes at forecast time.
+# The far-field locations (Munich, Stuttgart, Frankfurt, Berlin, Prague, Warsaw) were
+# exported from ECMWF/ERA5_LAND/DAILY_AGGR instead: their CSVs are already daily, use the
+# column name `total_precipitation_sum` (a daily total, not an hourly rate), and have no
+# hourly values to average. Including them raised an AssertionError in `get_era5_hourly`
+# and, once past that, would have fed the model daily sums in training against
+# 24-hour means at forecast time. Re-adding them requires a separate variable list and an
+# explicit per-variable aggregation rule. See DEVELOPMENT.md sections 4.2 and 4.5.
 era5_daily_locations:
   - "Defile"
   - "Schaffhausen"
   - "Basel"
-  - "Munich"
-  - "Stuttgart"
-  - "Frankfurt"
-  - "Berlin"
 
 era5_daily_variables:
   - "temperature_2m"


### PR DESCRIPTION
`configs/data/defile.yaml` listed `total_precipitation` in
`era5_daily_variables` with Munich, Stuttgart, Frankfurt and Berlin among
`era5_daily_locations`. Those four CSVs were exported from
ECMWF/ERA5_LAND/DAILY_AGGR (see data/era5/gee_code.js) and their only
precipitation column is `total_precipitation_sum`, so the assertion in
`get_era5_hourly` fired on Munich and `python src/train.py` with the committed
default config could not load its data at all. `configs/data/defile-small.yaml`
comments these out, which is why recent work on the small config was unaffected.

The column name is only the surface problem. `get_era5_daily` builds daily
values by taking `mean(dim="time")` over hourly data. For Defile, Schaffhausen
and Basel that is a true 24-hour mean. For the far-field locations the source is
already daily and stamped at 00:00, so after the union of time coordinates they
are NaN for 23 hours and the skipna mean returns the single daily value -- which
for precipitation is a daily *total*, not an hourly rate. At forecast time
`download_forecast_daily` fetches hourly data for every location and takes a
genuine 24-hour mean, so four of the seven daily locations had different
semantics in training than in inference, on top of a roughly 24x scale
difference on precipitation.

Rather than paper over that, this drops the far-field locations, which appear to
be exploratory leftovers (Prague and Warsaw were exported too and never used).
Every remaining daily location is backed by hourly ERA5, so the aggregation
means the same thing on both paths. Re-adding them is a deliberate change
requiring a separate variable list and an explicit per-variable aggregation rule;
the reasoning is recorded in a comment next to the list.

This changes nb_input_features_daily from 37 to 17 (the value is derived from the
config by a Hydra resolver, so no model config edit is needed), and therefore
requires retraining.
