### PR TITLE
Fix ProbaRMSE: average over surveyed hours, not over all 24

### DIFF
--- a/src/models/criterion.py
+++ b/src/models/criterion.py
@@ -159,11 +159,18 @@ class ProbaRMSE:
         epsilon = 1e-8
         pi = torch.acos(torch.zeros(1)).item() * 2
 
+        # Average over the hours actually covered by the survey.
+        # NB: this must divide by mask.sum(), not by the 24 hours of the day. Dividing by
+        # 24 (as torch.mean does) scales the implied target by survey_hours / 24, which
+        # varies from row to row, so a 3-hour and a 12-hour survey imply targets differing
+        # by a factor of 4 for the same true hourly rate.
+        mask_hours = torch.sum(mask, dim=1).clamp(min=epsilon)
+
         # Compute masked mean predictions (log-transformed)
-        y_masked = torch.mean(y_pred[:, 0, :] * mask, dim=1)
+        y_masked = torch.sum(y_pred[:, 0, :] * mask, dim=1) / mask_hours
 
         # Compute masked standard deviation with scaling and epsilon for stability
-        y_std_masked = epsilon + torch.mean(y_pred[:, 1, :] * mask, dim=1) / 4
+        y_std_masked = epsilon + torch.sum(y_pred[:, 1, :] * mask, dim=1) / mask_hours / 4
 
         # RMSE term: squared difference between log-transformed target and prediction
         rmse_term = torch.mean((torch.log1p(y.squeeze()) - y_masked) ** 2)


### PR DESCRIPTION
`ProbaRMSE.forward` computed `torch.mean(y_pred[:, 0, :] * mask, dim=1)`, i.e.
`sum(pred * mask) / 24`, and compared it against `log1p(observed hourly rate)`.
The correct denominator is `mask.sum()`, the number of hours the survey actually
covered.

As written, the implied target was scaled by `survey_hours / 24`, a factor that
varies row by row: a 3-hour survey and a 12-hour survey implied targets differing
by 4x for the same true hourly rate. Since survey length varies enormously in
this dataset -- from single hourly slots in the 2014-2016 era to full-day totals
in earlier years -- this injected a large, systematic, effort-dependent
distortion into the loss.

It also means the two loss terms disagreed about the quantity they were fitting:
`TweedieLoss` normalises correctly via `applyMask`, `ProbaRMSE` did not. The
per-species criterion weights in configs/experiment/ were tuned against that
inconsistency and should be re-tuned.

Uses a clamped `mask.sum(dim=1)` for both the mean and the std channel.
