### PR TITLE
Align single-run output directories with the checkpoint path prediction reads

### DIFF
--- a/configs/hydra/default.yaml
+++ b/configs/hydra/default.yaml
@@ -7,7 +7,12 @@ defaults:
 
 # output directory, generated dynamically on each run
 run:
-  dir: ${paths.log_dir}/${task_name}/runs/${now:%Y-%m-%d}_${now:%H-%M-%S}/${data.species}
+  # Use the underscored species name, matching `sweep.subdir` below and the checkpoint
+  # path that configs/predict.yaml reads
+  # (prod/models/${underscore:'${data.species}'}/checkpoints/best.ckpt). With the raw name
+  # here, scripts/move_checkpoints_to_prod.py promoted single-species runs to
+  # "prod/models/Black Kite/" while prediction looked in "prod/models/Black_Kite/".
+  dir: ${paths.log_dir}/${task_name}/runs/${now:%Y-%m-%d}_${now:%H-%M-%S}/${underscore:'${data.species}'}
 sweep:
   dir: ${paths.log_dir}/${task_name}/multiruns/${now:%Y-%m-%d}_${now:%H-%M-%S}
   subdir: ${underscore:'${data.species}'}

--- a/src/eval.py
+++ b/src/eval.py
@@ -10,6 +10,9 @@ from omegaconf import DictConfig, OmegaConf
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 OmegaConf.register_new_resolver("len", len)
 OmegaConf.register_new_resolver("eval", eval)
+# Required by configs/hydra/default.yaml (run.dir and sweep.subdir); without it eval.py
+# fails to resolve its own output directory.
+OmegaConf.register_new_resolver("underscore", lambda x: x.replace(" ", "_"))
 
 from src.utils import (
     RankedLogger,


### PR DESCRIPTION
`configs/hydra/default.yaml` built `run.dir` from the raw species name (with
spaces) while `sweep.subdir` used `${underscore:...}`.
`scripts/move_checkpoints_to_prod.py` promotes checkpoints using the run
subdirectory name verbatim, and `configs/predict.yaml` reads
`prod/models/${underscore:'${data.species}'}/checkpoints/best.ckpt`.

So promoting after a single-species run landed the checkpoint in
`prod/models/Black Kite/` while prediction looked in `prod/models/Black_Kite/`.
Multiruns happened to work because they go through `sweep.subdir`. Both
directory spellings currently exist in prod/models/, which is the fingerprint of
this bug.

Also registers the `underscore` resolver in src/eval.py. It was registered in
train.py and predict.py but not eval.py, so eval.py could not resolve
`sweep.subdir` and `python src/eval.py --multirun` failed outright -- and would
now fail on `run.dir` too.

The orphaned space-named directories under prod/models/ should be deleted
separately; this PR only stops new ones being created.
