### PR TITLE
Drop the untrained uncertainty output channel

### DIFF
--- a/configs/hparams_search/unet.yaml
+++ b/configs/hparams_search/unet.yaml
@@ -53,4 +53,7 @@ hydra:
       model.optimizer.weight_decay: interval(0.0001, 0.1)
       model.criterion.tweedie.p: interval(1, 2)
       model.criterion.tweedie.alpha: interval(.01, 10)
-      # model.criterion.rmse.alpha: interval(.1, .5)
+      # `rmse.alpha` used to mix an RMSE term against an untrained NLL term (DEVELOPMENT.md
+      # 4.8); that NLL term is gone, so `rmse.alpha` is now just this criterion's weight in
+      # the combined loss, like `tweedie.alpha` above. Uncomment to tune it the same way:
+      # model.criterion.rmse.alpha: interval(.01, 10)

--- a/configs/model/unet.yaml
+++ b/configs/model/unet.yaml
@@ -23,7 +23,10 @@ net:
   nb_lag_day: ${data.lag_day}
   nb_layer_daily: 6
   nb_hidden_features_daily: 128
-  nb_output_features: 2
+  # A second channel used to feed an uncertainty (NLL) term that never received gradient,
+  # since alpha=1 everywhere zeroed out its contribution to the loss (DEVELOPMENT.md 4.8).
+  # `ProbaRMSE` now only reads channel 0.
+  nb_output_features: 1
   dropout: True
 
 criterion:

--- a/src/models/criterion.py
+++ b/src/models/criterion.py
@@ -115,49 +115,42 @@ class TweedieLoss:
 @dataclass
 class ProbaRMSE:
     """
-    Probabilistic Root Mean Square Error Loss Function.
+    Masked RMSE loss on log1p-transformed counts.
 
-    This loss function combines a standard RMSE term with a negative log-likelihood term
-    for uncertainty quantification. It's designed for models that predict both mean and
-    standard deviation (uncertainty) values.
-
-    The loss consists of two components:
-    1. A weighted RMSE term between log-transformed predictions and targets
-    2. A negative log-likelihood term that penalizes poor uncertainty estimates
+    Used to combine a negative log-likelihood term against a second, model-predicted
+    "uncertainty" channel, weighted against the RMSE term by `alpha`. That channel was
+    never trained -- with `alpha` fixed at 1 in every config, the NLL term's contribution
+    to the loss was always multiplied by `(1 - alpha) = 0`, so it received no gradient
+    (DEVELOPMENT.md 4.8). The model has since dropped to a single output channel, and this
+    class dropped the NLL term along with it. `alpha` remains as this criterion's weight in
+    the combined loss, the same role `TweedieLoss.alpha` plays.
 
     Attributes:
-        alpha (float): Weighting factor for the combined loss. Default is 1.
-                      When alpha=1, only RMSE is used.
-                      When alpha=0, only negative log-likelihood is used.
-                      Values between 0 and 1 combine both terms.
+        alpha (float): Weight of this term in the combined loss. Default is 1.
     """
 
     alpha: float = 1.0
 
     def forward(self, y_pred, y, mask):
         """
-        Compute the probabilistic RMSE loss.
+        Compute the masked RMSE loss.
 
         Args:
-            y_pred (torch.Tensor): Predicted values with shape [batch_size, 2, time_steps].
-                                  Channel 0 contains mean predictions (log-transformed).
-                                  Channel 1 contains standard deviation predictions.
+            y_pred (torch.Tensor): Predicted values with shape [batch_size, 1, time_steps],
+                                  log-transformed.
             y (torch.Tensor): Ground truth target values with shape [batch_size, 1] or [batch_size].
                              Expected to be in original scale (not log-transformed).
             mask (torch.Tensor): Binary mask with shape [batch_size, time_steps].
                                 Indicates which time steps to include in the calculation.
 
         Returns:
-            torch.Tensor: Scalar loss value combining RMSE and negative log-likelihood terms.
+            torch.Tensor: Scalar RMSE loss value, scaled by alpha.
 
         Notes:
             - The function applies log1p transformation to targets for numerical stability
-            - Standard deviation is scaled by dividing by 4 (empirical scaling factor)
-            - Epsilon is added to prevent division by zero and log(0) issues
-            - The final loss is scaled by alpha, making it effectively alpha² * (weighted combination)
+            - Epsilon is added to prevent division by zero
         """
         epsilon = 1e-8
-        pi = torch.acos(torch.zeros(1)).item() * 2
 
         # Average over the hours actually covered by the survey.
         # NB: this must divide by mask.sum(), not by the 24 hours of the day. Dividing by
@@ -169,24 +162,10 @@ class ProbaRMSE:
         # Compute masked mean predictions (log-transformed)
         y_masked = torch.sum(y_pred[:, 0, :] * mask, dim=1) / mask_hours
 
-        # Compute masked standard deviation with scaling and epsilon for stability
-        y_std_masked = epsilon + torch.sum(y_pred[:, 1, :] * mask, dim=1) / mask_hours / 4
-
         # RMSE term: squared difference between log-transformed target and prediction
         rmse_term = torch.mean((torch.log1p(y.squeeze()) - y_masked) ** 2)
 
-        # Negative log-likelihood term: penalizes poor uncertainty estimates
-        nll_term = torch.mean(
-            (
-                (torch.log1p(y.squeeze()) - y_masked) ** 2 / (2 * y_std_masked)
-                + torch.log(2 * pi * y_std_masked) / 2
-            )
-        )
-
-        # Combine terms with alpha weighting
-        loss = self.alpha * rmse_term + (1 - self.alpha) * nll_term
-
-        return loss
+        return self.alpha * rmse_term
 
 
 # @dataclass


### PR DESCRIPTION
## Summary

- `nb_output_features: 2` fed a second channel into `ProbaRMSE` as an NLL uncertainty term,
  weighted against RMSE by `alpha`. Every experiment config fixes `alpha=1`, which
  multiplies the NLL term's contribution by `(1-alpha)=0` -- so that channel never received
  gradient and stayed essentially random (DEVELOPMENT.md 4.8), even though `save_test`
  exported `pred_count_up`/`pred_count_down` from it.
- Drops to one output channel; `ProbaRMSE` no longer computes the NLL term or the std it
  depended on, keeping `alpha` as this criterion's weight in the combined loss (same role
  `TweedieLoss.alpha` plays).
- No other code changes needed -- both places reading channel 1 already guard on
  `shape[1] == 2` / `"pred_count_down" in data.data_vars` and self-skip.

## Test plan

- [x] Unit check: gradient flows through the sole channel, no dead branch
- [x] `pytest tests/` (unaffected, still 14 passed / 5 skipped)
- [x] `train.py debug=default` end to end (fit -> validate -> test), no errors
- [ ] Retrain (tracked separately as Phase 2 in DEVELOPMENT.md)

App-facing uncertainty bands come from climatological quantiles, not the model, so nothing
user-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)