### PR TITLE
Fit normalisation stats on training dates only

### DIFF
--- a/src/data/defile_datamodule.py
+++ b/src/data/defile_datamodule.py
@@ -531,12 +531,23 @@ class DefileDataModule(LightningDataModule):
             # Compute transformation
             # Create a DataTransformers for each era5 data. This class does not store the data, only the transformation and the parameters of the transformation
             if self.compute_transform_data:
+                # Fit on training dates only. Fitting on the full (train+val+test) range
+                # leaks val/test distribution into the normalisation stats -- mild, but
+                # min/max normalisation is outlier-sensitive on top of it (DEVELOPMENT.md
+                # 4.9). Restricted by `count["date"]` rather than `count["year"]`, since the
+                # non-"period" split assigns individual rows, not whole years, so a given
+                # year can straddle train and test.
+                train_dates = count.loc[count["tvt"] == "train", "date"]
+
+                def _train_only(era5):
+                    return era5.sel(date=np.isin(era5["date"], train_dates))
+
                 transform_data = {
                     "year_used": lambda x: (x - 2000) / 100,
                     "doy": lambda x: (x - 183) / 366,
-                    "main": DataTransformer(dataset=self.era5_main),
-                    "hourly": DataTransformer(dataset=self.era5_hourly),
-                    "daily": DataTransformer(dataset=self.era5_daily),
+                    "main": DataTransformer(dataset=_train_only(self.era5_main)),
+                    "hourly": DataTransformer(dataset=_train_only(self.era5_hourly)),
+                    "daily": DataTransformer(dataset=_train_only(self.era5_daily)),
                 }
                 with open(os.path.join(self.data_dir, "transform_data.pickle"), "wb") as f:
                     cloudpickle.dump(transform_data, f)


### PR DESCRIPTION
## Summary

- `DataTransformer` was built from the full filtered weather arrays -- train, val and test
  dates alike -- before the split was used at all (DEVELOPMENT.md 4.9). Mild leakage, made
  worse by min/max normalisation being outlier-sensitive.
- Restricts fitting to `count["date"]` rows assigned `"train"`, not `count["year"]`: the
  non-`"period"` split assigns individual rows rather than whole years, so a given year can
  straddle train and test, and filtering by year would still leak in that case.
- `apply_transformers` still runs against the full, unrestricted era5 arrays afterward,
  same as before -- only what the stats are *fit* on changes, not what they're *applied* to.

## Test plan

- [x] Confirmed the fitted params actually move: `temperature_2m` mean shifts from 288.80
      to 289.36 K, precipitation's log-mean from -18.00 to -18.47 on a 2010-2025 slice
- [x] `pytest tests/` (unaffected)
- [x] `train.py debug=default` end to end (fit -> validate -> test), no errors
- [ ] Retrain (tracked separately as Phase 2 in DEVELOPMENT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)