### PR TITLE
Add a season guard to the daily prediction job

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -1,5 +1,6 @@
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple
-import time 
+import time
 
 import hydra
 import rootutils
@@ -16,6 +17,19 @@ from src.utils import RankedLogger
 
 log = RankedLogger(__name__, rank_zero_only=True)
 
+
+def is_in_season(doy_range, date) -> bool:
+    """Whether `date` falls within the inclusive [start, end] day-of-year range.
+
+    Training data is restricted to `doy_range` (mid-July to end of November by default),
+    so the model has never seen the rest of the year. The daily cron runs regardless,
+    which without this guard would publish confident extrapolations from a model with no
+    grounding for roughly seven months a year (DEVELOPMENT.md 4.11).
+    """
+    start, end = doy_range
+    return start <= date.timetuple().tm_yday <= end
+
+
 @hydra.main(version_base="1.3", config_path="../configs", config_name="predict.yaml")
 def main(cfg: DictConfig) -> None:
     """Main entry point for prediction.
@@ -25,6 +39,16 @@ def main(cfg: DictConfig) -> None:
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
     assert cfg.ckpt_path_pred
+
+    today = datetime.now(timezone.utc)
+    if not is_in_season(cfg.data.doy, today):
+        log.info(
+            f"Skipping prediction: today (doy {today.timetuple().tm_yday}, {today:%Y-%m-%d}) "
+            f"falls outside the trained season {tuple(cfg.data.doy)}. No forecast is "
+            f"written, so the daily job does not publish an extrapolation the model has no "
+            f"grounding for. See DEVELOPMENT.md 4.11."
+        )
+        return
 
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")
     datamodule: LightningDataModule = hydra.utils.instantiate(cfg.data)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,37 @@
+"""Tests for the season guard (DEVELOPMENT.md 4.11).
+
+Training is restricted to a day-of-year window; the daily cron runs every day of the year
+regardless. `is_in_season` is what stops the job from publishing a confident extrapolation
+for the seven months a year the model has never seen.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.predict import is_in_season
+
+DOY_RANGE = (196, 335)  # matches configs/data/defile.yaml
+
+
+@pytest.mark.parametrize(
+    "date_str, expected",
+    [
+        ("2026-01-15", False),  # deep off-season
+        ("2026-07-14", False),  # day before the season starts (doy 195)
+        ("2026-07-15", True),  # first day of the season (doy 196)
+        ("2026-09-15", True),  # mid-season
+        ("2026-12-01", True),  # last day of the season (doy 335)
+        ("2026-12-02", False),  # day after the season ends
+        ("2026-12-31", False),  # deep off-season, end of year
+    ],
+)
+def test_is_in_season_boundaries(date_str, expected):
+    date = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    assert is_in_season(DOY_RANGE, date) is expected
+
+
+def test_is_in_season_accepts_a_plain_list_like_omegaconf_gives():
+    """Hydra hands `cfg.data.doy` over as an OmegaConf ListConfig, not a tuple."""
+    date = datetime(2026, 9, 15, tzinfo=timezone.utc)
+    assert is_in_season([196, 335], date) is True


### PR DESCRIPTION
## Summary

The cron runs every day of the year, but training is restricted to `doy` 196-335
(mid-July to end of November). For roughly seven months a year the job was publishing
confident extrapolations from a model that had never seen that part of the year.
DEVELOPMENT.md 4.11.

`is_in_season(doy_range, date)` checks today (UTC) against `cfg.data.doy` before anything
else runs in `predict.py`. Out of season: logs why and returns without instantiating the
datamodule, model or trainer -- no Open-Meteo call, no checkpoint load, no NetCDF written.
In season: no-op, existing pipeline runs unchanged.

This only stops the backend from producing/uploading a fabricated forecast. Making the app
render out-of-season days as unavailable is a defileViz-side change, out of scope here.

## Test plan

- [x] 8 unit tests on `is_in_season` boundaries (doy 195/196/335/336) + OmegaConf ListConfig input
- [x] `data.doy=[1,10]` (excludes today) against the real pipeline: skips cleanly, no side effects
- [x] Default config (includes today) against the real pipeline: full run unchanged --
      loads the Common Buzzard checkpoint, calls the live Open-Meteo forecast API, writes
      `20260805_Common_Buzzard.nc` exactly as before
- [x] `pytest tests/` (22 passed / 5 skipped, up from 14/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)