### PR TITLE
Pin the forecast path to ecmwf_ifs025, matching ERA5's grid (4.19d)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,61 +22,38 @@ the model learns to depend on that isn't available then is a liability.
 ## Status
 
 Phases 0 and 1 are merged: `centralize-weather` (one `get_weather()` for training and
-forecasting), the season guard (4.11), and the uncertainty-channel drop (4.8). 4.9
+forecasting), the season guard (4.11), the uncertainty-channel drop (4.8), and 4.19d (the
+forecast path is now pinned to `ecmwf_ifs025`, matching ERA5's 0.25° grid — see below). 4.9
 (normalisation leakage) was fixed and then reverted — Raphaël's call, fitting on the full
-dataset isn't a real problem for this use case, so it's closed as won't-fix rather than
-carried as an open item. None of the `prod/models/` checkpoints have been retrained against
-any of this yet (Phase 2, below).
+dataset isn't a real problem for this use case, so it's closed as won't-fix. Training on
+Open-Meteo's Historical Forecast API (fine-tuning at matched lead times) is also closed as
+won't-fix. None of the `prod/models/` checkpoints have been retrained against any of this
+yet (Phase 2, below).
 
-## Open defects
+**4.19d, resolved but with a residual worth knowing about.** Root cause was confirmed, not
+just suspected: the forecast path didn't set `models=`, so Open-Meteo's `best_match` picked
+a model per location, resolving to **DWD ICON-D2 at 2 km** at Défilé — confirmed by matching
+returned grid coordinates against an explicit `models=dwd_icon_d2` request. Training uses
+ERA5 at 0.25° (~25-28 km) — a ~12x difference in grid spacing. Pinning the forecast path to
+`ecmwf_ifs025` (same 0.25° grid as `era5`, confirmed against the live API) measurably closes
+most of that gap:
 
-**4.19d The model trains on 25 km wind and is served ~2 km wind, and at Défilé those are
-substantially different fields.** Root cause now confirmed, not just suspected: the
-forecast path (`source="forecast"` in `src/data/weather.py`) doesn't set `models=`, so
-Open-Meteo's `best_match` picks a model per location. At Défilé that resolves to **DWD
-ICON-D2 at 2 km** — confirmed by comparing the returned grid coordinates (`lat=46.12,
-lon=5.92`) against an explicit `models=dwd_icon_d2` request, which snaps to the identical
-point. Training uses ERA5 pinned to `models=era5`, a 0.25° (~25-28 km) grid. So the
-mismatch is a ~12x difference in grid spacing between the two paths, not a subtlety.
-
-Measured over 61 days at Défilé, switching the forecast path from the default (ICON-D2) to
-`ecmwf_ifs025` — a real, working parameter value, confirmed against the live API, that
-resolves to the same 0.25° grid as `era5` (`lat=46.0, lon=6.0`):
-
-| vs ERA5 archive | default (ICON-D2, 2 km) | `ecmwf_ifs025` (0.25°) |
+| vs ERA5 archive, at Défilé | default (ICON-D2, 2 km) | `ecmwf_ifs025` (0.25°) |
 |---|---|---|
 | `u_component_of_wind_10m` corr | 0.27 | **0.55** |
 | `v_component_of_wind_10m` corr | 0.66 | **0.80** |
-| `u_component_of_wind_100m` corr | 0.50 | **0.65** |
-| `v_component_of_wind_100m` corr | 0.69 | **0.83** |
 | `u_wind_10m` std ratio (fcst/ERA5) | 1.73 | **0.95** |
-| `temperature_2m` corr / std ratio | 0.97 / 0.94 | 0.97 / **1.01** |
 
-Pinning to `ecmwf_ifs025` roughly doubles wind agreement and brings the variance ratio to
-near 1. It doesn't reach 1.0 corr — ERA5 is a reanalysis that assimilates observations,
-IFS-025 is a raw forecast, so some residual disagreement is expected even at matching
-resolution — but the improvement is large and real, not marginal.
+There's a domain reason to prefer the coarser product beyond consistency, too: birds
+crossing Défilé integrate wind over a section of the gorge at least 2-5 km wide, wider than
+ICON-D2's native resolution — 25 km is arguably closer to the biologically relevant scale.
 
-There's also a domain reason to prefer the coarser product on its own merits, independent
-of train/serve consistency: birds crossing Défilé integrate wind over a section of the
-gorge at least 2-5 km wide. ICON-D2's 2 km detail is finer than what's biologically
-relevant to a bird making a crossing decision over that width; a 25 km field is arguably
-closer to the right physical scale for the phenomenon, not just a compromise for
-consistency's sake.
-
-**Historical Forecast API, checked and corrected:** covers `2016-01-01` through a rolling
-window to roughly two weeks ahead of today (`2026-08-20` as of this check), not "since
-2024" as assumed going in. It carries the same `models=` catalog, including
-`ecmwf_ifs025`. About 10 years of archived past-forecast data at matching lead times — not
-long enough to replace the 60-year ERA5 training history, but plenty for the lead-day
-skill measurement in Phase 3, and for a fine-tune experiment at matching lead times if that
-turns out to be worth doing after the simpler `ecmwf_ifs025` pin is measured in production.
-
-**Recommended next step, not yet implemented:** pin the forecast path to `models=ecmwf_ifs025`
-in `src/data/weather.py`. Cheap (one parameter), well-supported by the numbers above, and
-the domain argument suggests it's not merely a stopgap. `tests/test_weather.py::test_wind_over_complex_terrain_is_documented_as_divergent`
-records the current (default-model) numbers so the effect can't be quietly forgotten;
-its tolerances would need loosening once the default model changes.
+A residual gap remains even at matched resolution — at flat Frankfurt the same comparison
+reaches ~0.93 corr, well above Défilé's 0.55 — because ERA5 is a reanalysis that
+assimilates observations and IFS-025 is a raw forecast, and terrain still amplifies that
+distinction. `tests/test_weather.py::test_wind_over_complex_terrain_is_documented_as_divergent`
+tracks it so it isn't forgotten. Not something to fix further; a real property of comparing
+these two products in complex terrain.
 
 ## Plan
 
@@ -88,11 +65,22 @@ and the independent Open-Meteo forecast client that used to drift apart from it.
 `fix/normalization-leakage` (4.9) was merged, then reverted — see Status above.
 
 **Phase 2 — retrain all 11 species checkpoints**, next. This is the actual gate for
-trusting any model-quality number; nothing before this point should be judged on accuracy.
-Worth doing once, after the `ecmwf_ifs025` pin below lands too, rather than retraining
-twice.
+trusting any model-quality number; nothing before this point — including the `ecmwf_ifs025`
+pin's actual effect on forecast skill, not just feature correlation — should be judged on
+accuracy.
 
-**Phase 3 — two research spikes**, branch per experiment, not urgent to land quickly:
+**Phase 3 — general modelling research, branch per experiment, not urgent to land quickly.**
+The main one: **location and variable selection.** `era5_main_variables`,
+`era5_hourly_locations`/`variables` and `era5_daily_locations`/`variables` were chosen once,
+at the start of the project, with no documented ablation since. Systematically test which
+locations and variables actually earn their place — leave-one-out or permutation-importance
+ablation on a trained model (the existing saliency/SHAP machinery in
+`src/plots/explanations.py` and `configs/model/unet.yaml`'s `compute_saliency` can inform
+this), or an Optuna sweep over feature subsets. The goal is a smaller, justified feature set,
+not just accuracy: fewer inputs means less surface area for the next drifted-unit or
+wrong-convention bug, and a smaller model to retrain each time a fix lands.
+
+Also in scope for this phase:
 - **Year selection.** `data/count/readme.md` documents real protocol changes: sporadic
   pigeon-focused coverage before 1993, daily volunteer monitoring from 1993, a salaried
   observer 2008–2016, two salaried observers from 2017. Recording granularity changed too
@@ -104,9 +92,14 @@ twice.
   available and untested; include it in the sweep. Bigger structural idea worth a follow-up:
   predict the *share* of the season's total per day/hour and forecast the annual total
   separately, removing most year-to-year variance from the hard part of the problem.
-- **Wind resolution** (4.19d, above) — pin `models=ecmwf_ifs025` on the forecast path, then
-  measure the effect on forecast skill (not just feature correlation) before deciding
-  whether the lead-day fine-tune on the Historical Forecast API is worth the extra work.
+
+For later, lower priority: **a probability envelope from the Tweedie loss itself**, rather
+than a second model-predicted output channel (the approach 4.8 removed for being
+untrained). The Tweedie distribution already has a defined variance-mean relationship
+(`Var(Y) = φ·μ^p`, `p` already fitted per species in `TweedieLoss`), which may be enough to
+derive calibrated uncertainty bands analytically instead of learning a second channel. Would
+also replace the climatological-quantile bands the app currently shows, which don't come
+from the model at all.
 
 **Phase 4 — Trektellen counts as model input.** Plumbing already exists: a working proxy at
 `https://defile.raphaelnussbaumer.com/trektellen/{siteId}/{yyyymmdd}` and a 47 MB NW-Europe

--- a/src/data/weather.py
+++ b/src/data/weather.py
@@ -54,6 +54,16 @@ FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
 # silently changing dataset and resolution part-way through the training history.
 ARCHIVE_MODEL = "era5"
 
+# The forecast path is pinned to ECMWF IFS at 0.25 deg, matching ARCHIVE_MODEL's grid.
+# Left unset, Open-Meteo's `best_match` picks per location -- at Defile that resolves to
+# DWD ICON-D2 at 2 km, a ~12x finer grid than the ERA5 training data (DEVELOPMENT.md
+# 4.19d). Measured over 61 days: pinning to ecmwf_ifs025 roughly doubles wind correlation
+# with the archive (u10 0.27->0.55) and brings its variance ratio from 1.73 to 0.95. Birds
+# crossing the gorge integrate wind over a section at least 2-5 km wide, so the coarser
+# grid is arguably the more relevant physical scale too, not just a train/serve
+# consistency trade-off.
+FORECAST_MODEL = "ecmwf_ifs025"
+
 # Read timeouts, in seconds. Archive requests span years and take far longer than a
 # forecast request, so the two are budgeted separately.
 ARCHIVE_TIMEOUT = 300
@@ -441,6 +451,7 @@ def fetch_forecast(locations, variables, lag_day=0, forecast_day=0, add_sun=Fals
             "longitude": lon,
             "past_days": lag_day,
             "forecast_days": forecast_day + 1,
+            "models": FORECAST_MODEL,
         }
     )
 

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -335,10 +335,11 @@ SYNOPTIC_MIN_CORR = {
 }
 
 # Wind correlation is asserted over flat terrain only, where the two products do track each
-# other (measured 0.81-0.92). This is what would catch a flipped or swapped wind convention:
-# it would drive these correlations to roughly zero or negative.
+# other (measured 0.88-0.94 with the forecast path pinned to ecmwf_ifs025). This is what
+# would catch a flipped or swapped wind convention: it would drive these correlations to
+# roughly zero or negative.
 FLAT_REFERENCE_LOCATION = "Frankfurt"
-FLAT_WIND_MIN_CORR = 0.65
+FLAT_WIND_MIN_CORR = 0.75
 
 PARITY_PAST_DAYS = 60
 
@@ -459,13 +460,18 @@ def test_wind_convention_holds_against_the_live_api_over_flat_terrain():
 
 @pytest.mark.network
 def test_wind_over_complex_terrain_is_documented_as_divergent():
-    """Records the resolution gap at Defile rather than asserting it away.
+    """Records the resolution gap at Defile that persists even after resolution-matching.
 
-    ERA5's 25 km cell cannot resolve the gorge; the forecast endpoint's high-resolution models
-    can. Measured over 61 days, 10 m wind correlates about 0.90 between the two products at
-    flat Frankfurt but only about 0.27 at Defile, with 1.7x the variance. Wind direction at a
-    bottleneck is one of the strongest drivers of raptor passage, so this is a real train/serve
-    distribution shift that unifying the provider did not remove. See DEVELOPMENT.md 4.19d.
+    The forecast path is pinned to ecmwf_ifs025 (0.25 deg, matching the ERA5 archive's grid),
+    which closed most of the original gap: before the pin, 10 m wind correlated only about
+    0.27 at Defile against 0.90 at flat Frankfurt (DWD ICON-D2's 2 km grid resolving the gorge
+    that ERA5's 25 km cell cannot). After the pin, both paths use the same 0.25 deg product,
+    and correlation at Defile rises to about 0.55 -- but Frankfurt rises further, to about
+    0.93. So terrain still drives a real, if smaller, disagreement between the two paths even
+    at matched resolution: ERA5 is a reanalysis that assimilates observations and IFS-025 is a
+    raw forecast, and that distinction still bites harder in complex terrain than over flat
+    ground. Wind direction at a bottleneck is one of the strongest drivers of raptor passage,
+    so this residual gap is still worth tracking. See DEVELOPMENT.md 4.19d.
 
     This test asserts only the direction of the effect, so it fails if the gap ever closes -
     which would mean the products, or this understanding of them, have changed.


### PR DESCRIPTION
## Summary

The forecast path didn't set `models=`, so Open-Meteo's `best_match` picked a model per
location -- at Defile that resolves to **DWD ICON-D2 at 2 km**, confirmed by matching
returned grid coordinates against an explicit `models=dwd_icon_d2` request. Training uses
ERA5 at 0.25 deg (~25-28 km), so the two paths were serving fields with a ~12x difference in
grid spacing (DEVELOPMENT.md 4.19d).

Pins `FORECAST_MODEL = "ecmwf_ifs025"`, the same 0.25 deg product ERA5 comes from, confirmed
to resolve to the identical grid point as `models=era5`.

Measured effect at Defile: u10 wind correlation with the ERA5 archive roughly doubles
(0.27 -> 0.55), variance ratio moves from 1.73 to 0.95. Birds crossing the gorge integrate
wind over a section at least 2-5 km wide, so the coarser grid is arguably the more
biologically relevant scale too, not just a train/serve consistency trade-off.

A residual gap remains even at matched resolution (0.55 at Defile vs ~0.93 at flat
Frankfurt) since ERA5 is a reanalysis and IFS-025 is a raw forecast -- updated
`tests/test_weather.py`'s divergence test and flat-terrain threshold (0.65 -> 0.75) to
reflect the new baseline.

Also updates DEVELOPMENT.md: closes 4.19d (residual noted, not actionable further); closes
the Historical Forecast API fine-tune idea as won't-fix per feedback; adds two Phase 3
research items -- location/variable ablation (the priority one) and a later idea to derive
uncertainty bands from the Tweedie distribution's own variance-mean relationship.

## Test plan

- [x] Confirmed `ecmwf_ifs025` returns all 15 needed variables (incl. CAPE) with zero nulls
- [x] Confirmed `forecast_days=7` / `past_days=7` both work (current usage needs 5/7)
- [x] `pytest tests/ -m network` (5 passed, including the updated divergence test)
- [x] `pytest tests/` (27 passed)
- [x] Verified `fetch_forecast` directly returns clean data end to end
- [ ] Full `predict.py` run hits an unrelated, pre-existing failure: the committed
      checkpoints are still 2-output-channel (pre-#37), current model is 1-channel. Not a
      regression from this change -- exactly why Phase 2 (retrain) exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)