### PR TITLE
Merge duplicate Trektellen count rows instead of inflating duration_h

### DIFF
--- a/notebooks/processing_count_data.ipynb
+++ b/notebooks/processing_count_data.ipynb
@@ -11,8 +11,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {},
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:21.095316Z",
+     "iopub.status.busy": "2026-08-06T17:50:21.095194Z",
+     "iopub.status.idle": "2026-08-06T17:50:22.219616Z",
+     "shell.execute_reply": "2026-08-06T17:50:22.218966Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -34,15 +41,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:22.221529Z",
+     "iopub.status.busy": "2026-08-06T17:50:22.221371Z",
+     "iopub.status.idle": "2026-08-06T17:50:35.371496Z",
+     "shell.execute_reply": "2026-08-06T17:50:35.370805Z"
+    }
+   },
    "outputs": [],
    "source": [
     "do = pd.concat(\n",
     "    [\n",
-    "        pd.read_excel(\"../data/count/count_2021.xlsx\", sheet_name=\"1966-2013\"),\n",
-    "        pd.read_excel(\"../data/count/count_2021.xlsx\", sheet_name=\"2014-2016\"),\n",
-    "        pd.read_excel(\"../data/count/count_2021.xlsx\", sheet_name=\"2017-2021\"),\n",
+    "        pd.read_excel(\"../data/count/raw_count/count_2021.xlsx\", sheet_name=\"1966-2013\"),\n",
+    "        pd.read_excel(\"../data/count/raw_count/count_2021.xlsx\", sheet_name=\"2014-2016\"),\n",
+    "        pd.read_excel(\"../data/count/raw_count/count_2021.xlsx\", sheet_name=\"2017-2021\"),\n",
     "    ]\n",
     ")\n",
     "\n",
@@ -87,8 +101,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:35.373461Z",
+     "iopub.status.busy": "2026-08-06T17:50:35.373331Z",
+     "iopub.status.idle": "2026-08-06T17:50:35.379161Z",
+     "shell.execute_reply": "2026-08-06T17:50:35.378656Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -114,8 +135,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:35.402104Z",
+     "iopub.status.busy": "2026-08-06T17:50:35.401947Z",
+     "iopub.status.idle": "2026-08-06T17:50:35.700782Z",
+     "shell.execute_reply": "2026-08-06T17:50:35.700230Z"
+    }
+   },
    "outputs": [],
    "source": [
     "period_recorded = (\n",
@@ -134,8 +162,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
-   "metadata": {},
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:35.702781Z",
+     "iopub.status.busy": "2026-08-06T17:50:35.702634Z",
+     "iopub.status.idle": "2026-08-06T17:50:40.412740Z",
+     "shell.execute_reply": "2026-08-06T17:50:40.412198Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -180,7 +215,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -200,8 +235,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
-   "metadata": {},
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:40.414340Z",
+     "iopub.status.busy": "2026-08-06T17:50:40.414225Z",
+     "iopub.status.idle": "2026-08-06T17:50:40.419210Z",
+     "shell.execute_reply": "2026-08-06T17:50:40.418708Z"
+    }
+   },
    "outputs": [],
    "source": [
     "period_to_expand = period_recorded[\n",
@@ -222,8 +264,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
-   "metadata": {},
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:40.421043Z",
+     "iopub.status.busy": "2026-08-06T17:50:40.420927Z",
+     "iopub.status.idle": "2026-08-06T17:50:41.543507Z",
+     "shell.execute_reply": "2026-08-06T17:50:41.542859Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def period2do(df):\n",
@@ -262,8 +311,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
-   "metadata": {},
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:41.545700Z",
+     "iopub.status.busy": "2026-08-06T17:50:41.545563Z",
+     "iopub.status.idle": "2026-08-06T17:50:41.550259Z",
+     "shell.execute_reply": "2026-08-06T17:50:41.549650Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -306,7 +362,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -318,8 +374,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
-   "metadata": {},
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:41.551988Z",
+     "iopub.status.busy": "2026-08-06T17:50:41.551860Z",
+     "iopub.status.idle": "2026-08-06T17:50:49.837304Z",
+     "shell.execute_reply": "2026-08-06T17:50:49.836676Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Filter for no overlaping periods\n",
@@ -330,8 +393,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
-   "metadata": {},
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:49.839143Z",
+     "iopub.status.busy": "2026-08-06T17:50:49.839011Z",
+     "iopub.status.idle": "2026-08-06T17:50:49.851903Z",
+     "shell.execute_reply": "2026-08-06T17:50:49.851125Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -374,7 +444,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -390,8 +460,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
-   "metadata": {},
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:49.853638Z",
+     "iopub.status.busy": "2026-08-06T17:50:49.853517Z",
+     "iopub.status.idle": "2026-08-06T17:50:49.863150Z",
+     "shell.execute_reply": "2026-08-06T17:50:49.862632Z"
+    }
+   },
    "outputs": [],
    "source": [
     "do_expended = (\n",
@@ -406,8 +483,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
-   "metadata": {},
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:49.865163Z",
+     "iopub.status.busy": "2026-08-06T17:50:49.865048Z",
+     "iopub.status.idle": "2026-08-06T17:50:49.876531Z",
+     "shell.execute_reply": "2026-08-06T17:50:49.875970Z"
+    }
+   },
    "outputs": [],
    "source": [
     "dot = pd.merge(\n",
@@ -421,8 +505,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
-   "metadata": {},
+   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:49.878350Z",
+     "iopub.status.busy": "2026-08-06T17:50:49.878228Z",
+     "iopub.status.idle": "2026-08-06T17:50:49.884154Z",
+     "shell.execute_reply": "2026-08-06T17:50:49.883514Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -625,7 +716,7 @@
        "[80039 rows x 8 columns]"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -654,15 +745,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
-   "metadata": {},
+   "execution_count": 14,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:50:49.885816Z",
+     "iopub.status.busy": "2026-08-06T17:50:49.885708Z",
+     "iopub.status.idle": "2026-08-06T17:51:03.366685Z",
+     "shell.execute_reply": "2026-08-06T17:51:03.366083Z"
+    }
+   },
    "outputs": [],
    "source": [
     "dn = []\n",
-    "for y in range(2022, 2024):\n",
+    "for y in range(2022, 2026):\n",
     "    dnn = pd.merge(\n",
-    "        pd.read_excel(f\"../data/count/raw_count/Trektellen_data_2422_{y}.xlsx\"),\n",
-    "        pd.read_excel(f\"../data/count/raw_count/Trektellen_headerdata_2422_{y}.xlsx\"),\n",
+    "        pd.read_excel(f\"../data/count/raw_count/trektellen/Trektellen_data_2422_{y}.xlsx\"),\n",
+    "        pd.read_excel(f\"../data/count/raw_count/trektellen/Trektellen_headerdata_2422_{y}.xlsx\"),\n",
     "        left_on=\"countid\",\n",
     "        right_on=\"id\",\n",
     "    )\n",
@@ -682,10 +780,27 @@
     "    .dt.tz_localize(local_tz, ambiguous=\"NaT\")\n",
     "    .dt.tz_convert(\"UTC\")\n",
     ")\n",
+    "\n",
+    "# Build datetime from date + timestamp explicitly (rather than via string\n",
+    "# concatenation) since `timestamp` is a mix of strings/time objects/NaN across\n",
+    "# yearly exports, and concatenating to a single string column makes\n",
+    "# pd.to_datetime infer one format from the whole combined series -- a format\n",
+    "# that matches only some rows silently turns the rest into NaT.\n",
+    "def _timestamp_to_str(t):\n",
+    "    if pd.isna(t) or t == \"\":\n",
+    "        return None\n",
+    "    if hasattr(t, \"strftime\"):\n",
+    "        return t.strftime(\"%H:%M:%S\")\n",
+    "    return str(t)\n",
+    "\n",
+    "\n",
+    "timestamp_str = dn[\"timestamp\"].apply(_timestamp_to_str)\n",
+    "has_time = timestamp_str.notna()\n",
     "dn[\"datetime\"] = (\n",
-    "    pd.to_datetime(dn[\"date\"] + \" \" + dn[\"timestamp\"])\n",
-    "    .dt.tz_localize(local_tz, ambiguous=\"NaT\")\n",
-    "    .dt.tz_convert(\"UTC\")\n",
+    "    pd.to_datetime(dn[\"date\"]) + pd.to_timedelta(timestamp_str.where(has_time, \"00:00:00\"))\n",
+    ").where(has_time, pd.NaT)\n",
+    "dn[\"datetime\"] = (\n",
+    "    dn[\"datetime\"].dt.tz_localize(local_tz, ambiguous=\"NaT\").dt.tz_convert(\"UTC\")\n",
     ")\n",
     "dn[\"date\"] = pd.to_datetime(dn[\"date\"])\n",
     "\n",
@@ -707,14 +822,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:03.368683Z",
+     "iopub.status.busy": "2026-08-06T17:51:03.368551Z",
+     "iopub.status.idle": "2026-08-06T17:51:03.381721Z",
+     "shell.execute_reply": "2026-08-06T17:51:03.381118Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "22\n"
+      "35\n"
      ]
     }
    ],
@@ -746,8 +868,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
-   "metadata": {},
+   "execution_count": 16,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:03.383668Z",
+     "iopub.status.busy": "2026-08-06T17:51:03.383538Z",
+     "iopub.status.idle": "2026-08-06T17:51:03.442120Z",
+     "shell.execute_reply": "2026-08-06T17:51:03.441552Z"
+    }
+   },
    "outputs": [],
    "source": [
     "period_recorded = (\n",
@@ -772,8 +901,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
-   "metadata": {},
+   "execution_count": 17,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:03.444114Z",
+     "iopub.status.busy": "2026-08-06T17:51:03.443969Z",
+     "iopub.status.idle": "2026-08-06T17:51:03.606261Z",
+     "shell.execute_reply": "2026-08-06T17:51:03.605480Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -818,7 +954,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -845,8 +981,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
-   "metadata": {},
+   "execution_count": 18,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:03.608265Z",
+     "iopub.status.busy": "2026-08-06T17:51:03.608119Z",
+     "iopub.status.idle": "2026-08-06T17:51:03.617839Z",
+     "shell.execute_reply": "2026-08-06T17:51:03.617255Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -954,68 +1097,68 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>298</th>\n",
-       "      <td>2554483</td>\n",
-       "      <td>2023-11-19</td>\n",
-       "      <td>2023-11-19 06:34:00+00:00</td>\n",
-       "      <td>2023-11-19 13:14:00+00:00</td>\n",
+       "      <th>515</th>\n",
+       "      <td>3199587</td>\n",
+       "      <td>2025-10-09</td>\n",
+       "      <td>2025-10-09 05:47:00+00:00</td>\n",
+       "      <td>2025-10-09 17:01:00+00:00</td>\n",
        "      <td>0</td>\n",
-       "      <td>110</td>\n",
+       "      <td>498</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0 days 06:40:00</td>\n",
+       "      <td>0 days 11:14:00</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>299</th>\n",
-       "      <td>2557350</td>\n",
-       "      <td>2023-11-23</td>\n",
-       "      <td>2023-11-23 10:30:00+00:00</td>\n",
-       "      <td>2023-11-23 14:50:00+00:00</td>\n",
+       "      <th>516</th>\n",
+       "      <td>3201905</td>\n",
+       "      <td>2025-10-10</td>\n",
+       "      <td>2025-10-10 05:46:00+00:00</td>\n",
+       "      <td>2025-10-10 16:59:00+00:00</td>\n",
        "      <td>0</td>\n",
-       "      <td>29</td>\n",
+       "      <td>677</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0 days 04:20:00</td>\n",
+       "      <td>0 days 11:13:00</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>300</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 08:45:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
+       "      <th>517</th>\n",
+       "      <td>3203720</td>\n",
+       "      <td>2025-10-11</td>\n",
+       "      <td>2025-10-11 05:48:00+00:00</td>\n",
+       "      <td>2025-10-11 16:57:00+00:00</td>\n",
        "      <td>0</td>\n",
-       "      <td>110</td>\n",
+       "      <td>339</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0 days 05:45:00</td>\n",
+       "      <td>0 days 11:09:00</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>301</th>\n",
-       "      <td>2567814</td>\n",
-       "      <td>2023-12-06</td>\n",
-       "      <td>2023-12-06 08:56:00+00:00</td>\n",
-       "      <td>2023-12-06 14:00:00+00:00</td>\n",
+       "      <th>518</th>\n",
+       "      <td>3205633</td>\n",
+       "      <td>2025-10-12</td>\n",
+       "      <td>2025-10-12 05:50:00+00:00</td>\n",
+       "      <td>2025-10-12 16:56:00+00:00</td>\n",
        "      <td>0</td>\n",
-       "      <td>79</td>\n",
+       "      <td>412</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0 days 05:04:00</td>\n",
+       "      <td>0 days 11:06:00</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>302</th>\n",
-       "      <td>2567815</td>\n",
-       "      <td>2023-11-11</td>\n",
-       "      <td>2023-11-11 06:40:00+00:00</td>\n",
-       "      <td>2023-11-11 18:14:00+00:00</td>\n",
+       "      <th>519</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 05:50:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
        "      <td>0</td>\n",
-       "      <td>177</td>\n",
+       "      <td>630</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0 days 11:34:00</td>\n",
+       "      <td>0 days 11:04:00</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>242 rows × 9 columns</p>\n",
+       "<p>456 rows × 9 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -1026,11 +1169,11 @@
        "4      2245836 2022-07-22 2022-07-22 07:00:00+00:00 2022-07-22 15:30:00+00:00   \n",
        "5      2246061 2022-07-23 2022-07-23 07:05:00+00:00 2022-07-23 15:30:00+00:00   \n",
        "..         ...        ...                       ...                       ...   \n",
-       "298    2554483 2023-11-19 2023-11-19 06:34:00+00:00 2023-11-19 13:14:00+00:00   \n",
-       "299    2557350 2023-11-23 2023-11-23 10:30:00+00:00 2023-11-23 14:50:00+00:00   \n",
-       "300    2567813 2023-12-07 2023-12-07 08:45:00+00:00 2023-12-07 14:30:00+00:00   \n",
-       "301    2567814 2023-12-06 2023-12-06 08:56:00+00:00 2023-12-06 14:00:00+00:00   \n",
-       "302    2567815 2023-11-11 2023-11-11 06:40:00+00:00 2023-11-11 18:14:00+00:00   \n",
+       "515    3199587 2025-10-09 2025-10-09 05:47:00+00:00 2025-10-09 17:01:00+00:00   \n",
+       "516    3201905 2025-10-10 2025-10-10 05:46:00+00:00 2025-10-10 16:59:00+00:00   \n",
+       "517    3203720 2025-10-11 2025-10-11 05:48:00+00:00 2025-10-11 16:57:00+00:00   \n",
+       "518    3205633 2025-10-12 2025-10-12 05:50:00+00:00 2025-10-12 16:56:00+00:00   \n",
+       "519    3207539 2025-10-13 2025-10-13 05:50:00+00:00 2025-10-13 16:54:00+00:00   \n",
        "\n",
        "     count_na_datetime  count  count_na_datetime_prop period_duration  \\\n",
        "1                    0     10                0.000000 0 days 08:35:00   \n",
@@ -1039,11 +1182,11 @@
        "4                    2     23                0.086957 0 days 08:30:00   \n",
        "5                    0     24                0.000000 0 days 08:25:00   \n",
        "..                 ...    ...                     ...             ...   \n",
-       "298                  0    110                0.000000 0 days 06:40:00   \n",
-       "299                  0     29                0.000000 0 days 04:20:00   \n",
-       "300                  0    110                0.000000 0 days 05:45:00   \n",
-       "301                  0     79                0.000000 0 days 05:04:00   \n",
-       "302                  0    177                0.000000 0 days 11:34:00   \n",
+       "515                  0    498                0.000000 0 days 11:14:00   \n",
+       "516                  0    677                0.000000 0 days 11:13:00   \n",
+       "517                  0    339                0.000000 0 days 11:09:00   \n",
+       "518                  0    412                0.000000 0 days 11:06:00   \n",
+       "519                  0    630                0.000000 0 days 11:04:00   \n",
        "\n",
        "     period_in_day  \n",
        "1                1  \n",
@@ -1052,16 +1195,16 @@
        "4                1  \n",
        "5                1  \n",
        "..             ...  \n",
-       "298              1  \n",
-       "299              1  \n",
-       "300              1  \n",
-       "301              1  \n",
-       "302              1  \n",
+       "515              1  \n",
+       "516              1  \n",
+       "517              1  \n",
+       "518              1  \n",
+       "519              1  \n",
        "\n",
-       "[242 rows x 9 columns]"
+       "[456 rows x 9 columns]"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1083,8 +1226,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
-   "metadata": {},
+   "execution_count": 19,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:03.619519Z",
+     "iopub.status.busy": "2026-08-06T17:51:03.619377Z",
+     "iopub.status.idle": "2026-08-06T17:51:03.729107Z",
+     "shell.execute_reply": "2026-08-06T17:51:03.728448Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def period2dn(df):\n",
@@ -1117,8 +1267,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
-   "metadata": {},
+   "execution_count": 20,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:03.730762Z",
+     "iopub.status.busy": "2026-08-06T17:51:03.730634Z",
+     "iopub.status.idle": "2026-08-06T17:51:03.735272Z",
+     "shell.execute_reply": "2026-08-06T17:51:03.734725Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1161,7 +1318,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1172,8 +1329,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
-   "metadata": {},
+   "execution_count": 21,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:03.736878Z",
+     "iopub.status.busy": "2026-08-06T17:51:03.736753Z",
+     "iopub.status.idle": "2026-08-06T17:51:11.568944Z",
+     "shell.execute_reply": "2026-08-06T17:51:11.568200Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Filter for no overlaping periods\n",
@@ -1184,8 +1348,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
-   "metadata": {},
+   "execution_count": 22,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:11.571154Z",
+     "iopub.status.busy": "2026-08-06T17:51:11.571018Z",
+     "iopub.status.idle": "2026-08-06T17:51:11.593126Z",
+     "shell.execute_reply": "2026-08-06T17:51:11.592521Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1279,58 +1450,58 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>36937</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:14:56+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 08:45:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>89</td>\n",
-       "      <td>17</td>\n",
+       "      <th>80834</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:05:55+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 05:50:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>268</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>36938</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:15:00+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 08:45:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>101</td>\n",
+       "      <th>80835</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:07:32+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 05:50:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>278</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80836</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:09:49+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 05:50:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>289</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80837</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:23:35+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 05:50:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>278</td>\n",
        "      <td>11</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>36939</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:17:02+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 08:45:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>89</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36940</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:19:03+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 08:45:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>89</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36941</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:21:38+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 08:45:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>89</td>\n",
-       "      <td>4</td>\n",
+       "      <th>80838</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:26:57+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 05:50:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>402</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>36942 rows × 7 columns</p>\n",
+       "<p>80839 rows × 7 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -1341,11 +1512,11 @@
        "3        2244952                       NaT 2022-07-18   \n",
        "4        2245190 2022-07-19 08:16:04+00:00 2022-07-19   \n",
        "...          ...                       ...        ...   \n",
-       "36937    2567813 2023-12-07 14:14:56+00:00 2023-12-07   \n",
-       "36938    2567813 2023-12-07 14:15:00+00:00 2023-12-07   \n",
-       "36939    2567813 2023-12-07 14:17:02+00:00 2023-12-07   \n",
-       "36940    2567813 2023-12-07 14:19:03+00:00 2023-12-07   \n",
-       "36941    2567813 2023-12-07 14:21:38+00:00 2023-12-07   \n",
+       "80834    3207539 2025-10-13 16:05:55+00:00 2025-10-13   \n",
+       "80835    3207539 2025-10-13 16:07:32+00:00 2025-10-13   \n",
+       "80836    3207539 2025-10-13 16:09:49+00:00 2025-10-13   \n",
+       "80837    3207539 2025-10-13 16:23:35+00:00 2025-10-13   \n",
+       "80838    3207539 2025-10-13 16:26:57+00:00 2025-10-13   \n",
        "\n",
        "                          start                       end  speciesid  count  \n",
        "0     2022-07-18 07:05:00+00:00 2022-07-18 15:35:00+00:00         89      1  \n",
@@ -1354,16 +1525,16 @@
        "3     2022-07-18 07:05:00+00:00 2022-07-18 15:35:00+00:00         88    126  \n",
        "4     2022-07-19 07:00:00+00:00 2022-07-19 15:35:00+00:00       1067      1  \n",
        "...                         ...                       ...        ...    ...  \n",
-       "36937 2023-12-07 08:45:00+00:00 2023-12-07 14:30:00+00:00         89     17  \n",
-       "36938 2023-12-07 08:45:00+00:00 2023-12-07 14:30:00+00:00        101     11  \n",
-       "36939 2023-12-07 08:45:00+00:00 2023-12-07 14:30:00+00:00         89      5  \n",
-       "36940 2023-12-07 08:45:00+00:00 2023-12-07 14:30:00+00:00         89      2  \n",
-       "36941 2023-12-07 08:45:00+00:00 2023-12-07 14:30:00+00:00         89      4  \n",
+       "80834 2025-10-13 05:50:00+00:00 2025-10-13 16:54:00+00:00        268      1  \n",
+       "80835 2025-10-13 05:50:00+00:00 2025-10-13 16:54:00+00:00        278      1  \n",
+       "80836 2025-10-13 05:50:00+00:00 2025-10-13 16:54:00+00:00        289      7  \n",
+       "80837 2025-10-13 05:50:00+00:00 2025-10-13 16:54:00+00:00        278     11  \n",
+       "80838 2025-10-13 05:50:00+00:00 2025-10-13 16:54:00+00:00        402      1  \n",
        "\n",
-       "[36942 rows x 7 columns]"
+       "[80839 rows x 7 columns]"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1390,15 +1561,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
-   "metadata": {},
+   "execution_count": 23,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:11.594878Z",
+     "iopub.status.busy": "2026-08-06T17:51:11.594755Z",
+     "iopub.status.idle": "2026-08-06T17:51:11.599573Z",
+     "shell.execute_reply": "2026-08-06T17:51:11.598962Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "258594\n",
-      "257978\n"
+      "565873\n",
+      "565124\n"
      ]
     }
    ],
@@ -1422,8 +1600,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
-   "metadata": {},
+   "execution_count": 24,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:11.601287Z",
+     "iopub.status.busy": "2026-08-06T17:51:11.601135Z",
+     "iopub.status.idle": "2026-08-06T17:51:19.707240Z",
+     "shell.execute_reply": "2026-08-06T17:51:19.706465Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def updatePeriod(row):\n",
@@ -1453,8 +1638,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
-   "metadata": {},
+   "execution_count": 25,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:19.709068Z",
+     "iopub.status.busy": "2026-08-06T17:51:19.708942Z",
+     "iopub.status.idle": "2026-08-06T17:51:19.715794Z",
+     "shell.execute_reply": "2026-08-06T17:51:19.715148Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1555,63 +1747,63 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>36937</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:14:56+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 14:00:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>89</td>\n",
-       "      <td>17</td>\n",
-       "      <td>0 days 00:30:00</td>\n",
+       "      <th>80834</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:05:55+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 16:00:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>268</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0 days 00:54:00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>36938</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:15:00+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 14:00:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>101</td>\n",
+       "      <th>80835</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:07:32+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 16:00:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>278</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0 days 00:54:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80836</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:09:49+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 16:00:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>289</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0 days 00:54:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80837</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:23:35+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 16:00:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>278</td>\n",
        "      <td>11</td>\n",
-       "      <td>0 days 00:30:00</td>\n",
+       "      <td>0 days 00:54:00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>36939</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:17:02+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 14:00:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>89</td>\n",
-       "      <td>5</td>\n",
-       "      <td>0 days 00:30:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36940</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:19:03+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 14:00:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>89</td>\n",
-       "      <td>2</td>\n",
-       "      <td>0 days 00:30:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36941</th>\n",
-       "      <td>2567813</td>\n",
-       "      <td>2023-12-07 14:21:38+00:00</td>\n",
-       "      <td>2023-12-07</td>\n",
-       "      <td>2023-12-07 14:00:00+00:00</td>\n",
-       "      <td>2023-12-07 14:30:00+00:00</td>\n",
-       "      <td>89</td>\n",
-       "      <td>4</td>\n",
-       "      <td>0 days 00:30:00</td>\n",
+       "      <th>80838</th>\n",
+       "      <td>3207539</td>\n",
+       "      <td>2025-10-13 16:26:57+00:00</td>\n",
+       "      <td>2025-10-13</td>\n",
+       "      <td>2025-10-13 16:00:00+00:00</td>\n",
+       "      <td>2025-10-13 16:54:00+00:00</td>\n",
+       "      <td>402</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0 days 00:54:00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>36854 rows × 8 columns</p>\n",
+       "<p>80732 rows × 8 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -1622,11 +1814,11 @@
        "3        2244952                       NaT 2022-07-18   \n",
        "4        2245190 2022-07-19 08:16:04+00:00 2022-07-19   \n",
        "...          ...                       ...        ...   \n",
-       "36937    2567813 2023-12-07 14:14:56+00:00 2023-12-07   \n",
-       "36938    2567813 2023-12-07 14:15:00+00:00 2023-12-07   \n",
-       "36939    2567813 2023-12-07 14:17:02+00:00 2023-12-07   \n",
-       "36940    2567813 2023-12-07 14:19:03+00:00 2023-12-07   \n",
-       "36941    2567813 2023-12-07 14:21:38+00:00 2023-12-07   \n",
+       "80834    3207539 2025-10-13 16:05:55+00:00 2025-10-13   \n",
+       "80835    3207539 2025-10-13 16:07:32+00:00 2025-10-13   \n",
+       "80836    3207539 2025-10-13 16:09:49+00:00 2025-10-13   \n",
+       "80837    3207539 2025-10-13 16:23:35+00:00 2025-10-13   \n",
+       "80838    3207539 2025-10-13 16:26:57+00:00 2025-10-13   \n",
        "\n",
        "                          start                       end  speciesid  count  \\\n",
        "0     2022-07-18 07:05:00+00:00 2022-07-18 15:35:00+00:00         89      1   \n",
@@ -1635,11 +1827,11 @@
        "3     2022-07-18 07:05:00+00:00 2022-07-18 15:35:00+00:00         88    126   \n",
        "4     2022-07-19 08:00:00+00:00 2022-07-19 09:00:00+00:00       1067      1   \n",
        "...                         ...                       ...        ...    ...   \n",
-       "36937 2023-12-07 14:00:00+00:00 2023-12-07 14:30:00+00:00         89     17   \n",
-       "36938 2023-12-07 14:00:00+00:00 2023-12-07 14:30:00+00:00        101     11   \n",
-       "36939 2023-12-07 14:00:00+00:00 2023-12-07 14:30:00+00:00         89      5   \n",
-       "36940 2023-12-07 14:00:00+00:00 2023-12-07 14:30:00+00:00         89      2   \n",
-       "36941 2023-12-07 14:00:00+00:00 2023-12-07 14:30:00+00:00         89      4   \n",
+       "80834 2025-10-13 16:00:00+00:00 2025-10-13 16:54:00+00:00        268      1   \n",
+       "80835 2025-10-13 16:00:00+00:00 2025-10-13 16:54:00+00:00        278      1   \n",
+       "80836 2025-10-13 16:00:00+00:00 2025-10-13 16:54:00+00:00        289      7   \n",
+       "80837 2025-10-13 16:00:00+00:00 2025-10-13 16:54:00+00:00        278     11   \n",
+       "80838 2025-10-13 16:00:00+00:00 2025-10-13 16:54:00+00:00        402      1   \n",
        "\n",
        "             duration  \n",
        "0     0 days 08:30:00  \n",
@@ -1648,16 +1840,16 @@
        "3     0 days 08:30:00  \n",
        "4     0 days 01:00:00  \n",
        "...               ...  \n",
-       "36937 0 days 00:30:00  \n",
-       "36938 0 days 00:30:00  \n",
-       "36939 0 days 00:30:00  \n",
-       "36940 0 days 00:30:00  \n",
-       "36941 0 days 00:30:00  \n",
+       "80834 0 days 00:54:00  \n",
+       "80835 0 days 00:54:00  \n",
+       "80836 0 days 00:54:00  \n",
+       "80837 0 days 00:54:00  \n",
+       "80838 0 days 00:54:00  \n",
        "\n",
-       "[36854 rows x 8 columns]"
+       "[80732 rows x 8 columns]"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1676,14 +1868,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
-   "metadata": {},
+   "execution_count": 26,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:19.717542Z",
+     "iopub.status.busy": "2026-08-06T17:51:19.717395Z",
+     "iopub.status.idle": "2026-08-06T17:51:19.723793Z",
+     "shell.execute_reply": "2026-08-06T17:51:19.723201Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "144\n"
+      "344\n"
      ]
     }
    ],
@@ -1701,8 +1900,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
-   "metadata": {},
+   "execution_count": 27,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:19.725814Z",
+     "iopub.status.busy": "2026-08-06T17:51:19.725672Z",
+     "iopub.status.idle": "2026-08-06T17:51:19.731305Z",
+     "shell.execute_reply": "2026-08-06T17:51:19.730783Z"
+    }
+   },
    "outputs": [],
    "source": [
     "period = dn2[[\"start\", \"end\", \"duration\", \"date\"]].drop_duplicates()"
@@ -1710,8 +1916,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
-   "metadata": {},
+   "execution_count": 28,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:19.733044Z",
+     "iopub.status.busy": "2026-08-06T17:51:19.732913Z",
+     "iopub.status.idle": "2026-08-06T17:51:19.736887Z",
+     "shell.execute_reply": "2026-08-06T17:51:19.736366Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1751,7 +1964,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1763,8 +1976,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
-   "metadata": {},
+   "execution_count": 29,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:19.738331Z",
+     "iopub.status.busy": "2026-08-06T17:51:19.738235Z",
+     "iopub.status.idle": "2026-08-06T17:51:19.741956Z",
+     "shell.execute_reply": "2026-08-06T17:51:19.741514Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1804,7 +2024,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1816,8 +2036,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
-   "metadata": {},
+   "execution_count": 30,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:19.743535Z",
+     "iopub.status.busy": "2026-08-06T17:51:19.743428Z",
+     "iopub.status.idle": "2026-08-06T17:51:21.448619Z",
+     "shell.execute_reply": "2026-08-06T17:51:21.448086Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1857,7 +2084,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1869,22 +2096,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
-   "metadata": {},
+   "execution_count": 31,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:21.450368Z",
+     "iopub.status.busy": "2026-08-06T17:51:21.450232Z",
+     "iopub.status.idle": "2026-08-06T17:51:21.596133Z",
+     "shell.execute_reply": "2026-08-06T17:51:21.595638Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x16cc06080>]"
+       "[<matplotlib.lines.Line2D at 0x1305a36d0>]"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGeCAYAAAA0WWMxAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA/9ElEQVR4nO3deXxU5aH/8e9kkkxCSAYSyAYJ+x42QTSAyiaIgFrrbpHq7WIVl2Kt4nKltjXa9me1tdra3p/VX6v2ti611xUruFxwAUQFFDeWCITIloQt6/n9EWaYNZmZnDmzfd6vV14wM2fmPGfOmXO+5znP8xybYRiGAAAALJIW6wIAAIDUQvgAAACWInwAAABLET4AAIClCB8AAMBShA8AAGApwgcAALAU4QMAAFiK8AEAACyVHusC+Gpra9POnTuVm5srm80W6+IAAIAQGIahhoYGlZaWKi2tk7oNI0yvv/66MX/+fKOkpMSQZDzzzDNBp/3e975nSDJ+/etfh/z51dXVhiT++OOPP/744y8B/6qrqzs91odd83Ho0CGNHTtWl19+ub75zW8Gne7ZZ5/VO++8o9LS0rA+Pzc3V5JUXV2tvLy8cIsHAABioL6+XmVlZe7jeEfCDh9z587V3LlzO5xmx44dWrx4sV5++WXNmzcvrM93XWrJy8sjfAAAkGBCaTJhepuPtrY2LVy4UDfeeKNGjRrV6fSNjY1qbGx0P66vrze7SAAAII6Y3tvlnnvuUXp6uq699tqQpq+qqpLT6XT/lZWVmV0kAAAQR0wNH2vXrtX999+vP//5zyH3VFm6dKnq6urcf9XV1WYWCQAAxBlTw8ebb76p2tpalZeXKz09Xenp6dq2bZtuuOEG9e/fP+B7HA6Hu30H7TwAAEh+prb5WLhwoWbNmuX13Jw5c7Rw4UJdfvnlZs4KAAAkqLDDx8GDB/X555+7H2/ZskXr169Xfn6+ysvLVVBQ4DV9RkaGiouLNWzYsK6XFgAAJLyww8eaNWs0ffp09+MlS5ZIkhYtWqQ///nPphUMAAAkp7DDx7Rp02QYRsjTb926NdxZAACAJMaN5QAAgKUIHwAAwFKEDwAAYCnCBwAAsBThIwKvbKzR/a9+pvqjzbEuCgAACcf0G8slu6aWNn3v/62VJOVlp+vyKQNiXCIAABILNR9h8qztONrcFsOSAACQmAgfYaqpO+r+v51vDwCAsHH4DFNrW+gDrAEAAH+EDwAAYCnCRxd8uvug9h9qinUxAABIKISPLvjH2q807zdvxroYAAAkFMJHF+2sOxrWjfYAAEh1hA8T0AgVAIDQET5M0EL4AAAgZIQPExA+AAAIHeEjTIFiRksrI50CABAqwocJGGYdAIDQET5McLCxJdZFAAAgYRA+TGCzxboEAAAkDsIHAACwFOEDAABYivABAAAsRfgAAACWInwAAABLET4AAIClCB9h4g62AAB0DeHDBOQRAABCR/gAAACWInwAAABLET4AAIClCB8AAMBShA8AAGApwgcAALAU4QMAAFiK8BEmhvQAAKBrCB8AAMBShA9TUB8CAECoCB8AAMBSYYePN954QwsWLFBpaalsNpueffZZ92vNzc266aabNHr0aOXk5Ki0tFSXXXaZdu7caWaZAQBAAgs7fBw6dEhjx47VAw884Pfa4cOHtW7dOt1+++1at26dnn76aX366ac666yzTCksAABIfOnhvmHu3LmaO3duwNecTqeWL1/u9dxvf/tbTZo0Sdu3b1d5eXlkpQQAAEkj7PARrrq6OtlsNvXo0SPg642NjWpsbHQ/rq+vj3aRAABADEW1wenRo0d1880365JLLlFeXl7AaaqqquR0Ot1/ZWVl0SwSAACIsaiFj+bmZl100UVqa2vTgw8+GHS6pUuXqq6uzv1XXV0drSKZwqBXLQAAXRKVyy7Nzc264IILtGXLFr322mtBaz0kyeFwyOFwRKMYAAAgDpkePlzB47PPPtOKFStUUFBg9iwAAEACCzt8HDx4UJ9//rn78ZYtW7R+/Xrl5+ertLRU5513ntatW6f/+Z//UWtrq2pqaiRJ+fn5yszMNK/kcYRLMQAAhC7s8LFmzRpNnz7d/XjJkiWSpEWLFmnZsmV67rnnJEnjxo3zet+KFSs0bdq0yEsKAACSQtjhY9q0aTI6ONXv6DUAAADu7QIAACxF+AAAAJYifAAAAEsRPsJGmxYAALqC8AEAACxF+AAAAJYifAAAAEsRPkxAKxAAAEJH+AAAAJYifAAAAEsRPgAAgKUIHwAAwFKEjzBx3zwAALqG8AEAACxF+AAAAJYifAAAAEsRPgAAgKUIHyagESoAAKEjfAAAAEsRPgAAgKUIHwAAwFKEDwAAYCnCR5hoWwoAQNcQPgAAgKUIHwAAwFKEDwAAYCnChwkMWoIAABAywgcAALAU4QMAAFiK8AEAACxF+EDS2FV3RKf+YoWuf/L9WBcFANABwkeYuINt/Pr3x7Xavu+wnl2/M9ZFAQB0gPCBpNTaRkoEgHhF+EDSyLDb3P9vbm2LYUkAAB0hfCBppKcd35wJHwAQvwgfSBrpHjUfLa1cdgGAeEX4MAGNUOODPe14+LjxHx/qn+t3xLA0AIBgCB9ISq9+vFt3PLcx1sUAAARA+EDSamqh3QcAxCPCB5JOnx7ZsS4CAKADYYePN954QwsWLFBpaalsNpueffZZr9cNw9CyZctUWlqq7OxsTZs2TRs3Jk/1t0EDDwAAuiTs8HHo0CGNHTtWDzzwQMDXf/GLX+jee+/VAw88oPfee0/FxcU6/fTT1dDQ0OXCAgCAxJce7hvmzp2ruXPnBnzNMAzdd999uvXWW3XuuedKkh599FEVFRXp8ccf1/e///2uldYiza1tenfLPp1Q3lPZmfZYFwcAgKRiapuPLVu2qKamRrNnz3Y/53A4dNppp2nVqlUB39PY2Kj6+nqvv1j71cubdemf3tFVf10b66IgDFwRA4DEYGr4qKmpkSQVFRV5PV9UVOR+zVdVVZWcTqf7r6yszMwiReSx1dskSSs2fx3jkiDe/P71L/S9x9box//4QF83NMa6OACQkKLS28Vms3k9NgzD7zmXpUuXqq6uzv1XXV0djSIBXbb3YKPufvETvbJpt/57zVd6/kPungsAkQi7zUdHiouLJbXXgJSUlLifr62t9asNcXE4HHI4HGYWw3JU96eGZp8h230fAwBCY2rNx4ABA1RcXKzly5e7n2tqatLrr7+uyZMnmzkrAACQoMKu+Th48KA+//xz9+MtW7Zo/fr1ys/PV3l5ua6//nrdddddGjJkiIYMGaK77rpL3bp10yWXXGJqwQEAQGIKO3ysWbNG06dPdz9esmSJJGnRokX685//rB//+Mc6cuSIrrrqKu3fv18nnXSSXnnlFeXm5ppX6hiioj1+sW4AIDGEHT6mTZvW4SifNptNy5Yt07Jly7pSLqDLaIsDAPGJe7sg6QTpWAUAiBOEjwAMKvATmlXhg+0EACJD+ABCRNgAAHMQPgAAgKUIHwAAwFKEDxNQHR8fOuqFBQCIH4QPJB2b6O4CAPGM8AEAACxF+AgTNfsAAHQN4QMIkW/wJIgCQGQIHwFwUAEAIHoIHwAAwFKEDyQd7u0CAPGN8IGk48oejL8CAPGJ8AEAACxF+DABDVQBAAgd4QOIEJkTACJD+AgT7QjiV7RroFjzAGAOwgcAALAU4SMAznATm42+tgAQ1wgfAADAUoQPAABgKcIHAACwFOEDAABYivCBpGF1N2gGlwOAyBA+kHSi1dfFIG0AgCkIH+Hi+BP/jqUPsgIAxKeUDh+1DUf1k39t1Oe1DbEuCgAAKSOlw8f1T67XI/+7VfN+85b3C5wxAwAQNSkTPlpa2/STf23UP9fvcD/3QfUBSVJjS1uMSgUAQOpJj3UBrNJmSI/871al2aRpwwrlzM6IdZFgMtp4AEBiSJmaj7RjjRDbDKmxuTW2hQEAIIWlTPhIt6e5AwiSW/S62vo8pnEQAEQkZcIHAACID4QPE9DWAACA0BE+wkTOAACga1IyfBAgkhM1UACQGFIqfNhstDgFACDWUip8hIpeDImNkAkA8c308NHS0qLbbrtNAwYMUHZ2tgYOHKg777xTbW2MIgprWBU9uMwDAJExfYTTe+65R7///e/16KOPatSoUVqzZo0uv/xyOZ1OXXfddWbPDgiKbAAA8cn08LF69WqdffbZmjdvniSpf//+euKJJ7RmzRqzZwUAABKQ6Zddpk6dqn//+9/69NNPJUkffPCB3nrrLZ155pkBp29sbFR9fb3XX7RRXQ4AQOyYXvNx0003qa6uTsOHD5fdbldra6t+/vOf6+KLLw44fVVVlX7yk5+YXYyAaIaY3MiUAJAYTK/5+Nvf/qa//OUvevzxx7Vu3To9+uij+tWvfqVHH3004PRLly5VXV2d+6+6utrsIpkqUK0JvWMAAAid6TUfN954o26++WZddNFFkqTRo0dr27Ztqqqq0qJFi/ymdzgccjgcZhcDKYyetgAQ30yv+Th8+LDS0rw/1m6309UWAABIikLNx4IFC/Tzn/9c5eXlGjVqlN5//33de++9uuKKK8yeVZcFG4yKBqkAAESP6eHjt7/9rW6//XZdddVVqq2tVWlpqb7//e/rP//zP82eVcRcbTQMUgbCwOYCAOYwPXzk5ubqvvvu03333Wf2R3cZbQGSG2ESABID93YBAACWInwg6dgY0QUA4hrhA0mHy2sAEN9SOnxw6/UkRxMQAIhLKRk+XO0SI2mgGGg0U6vaOe4/1KR3vtxLw8o4wXoAgMikVPhI9LYA0361Uhc+/LZe2bQ71kWJS9GOAgyjDwDmSKnwEap4PcTUHWmWJP37Y8IHACBxET4AAIClCB8AAMBSKR0+6O0CAID1UjJ8xGubDgAAUkFqhQ+fig66SiYZVicAJITUCh+AiciuABAZwkeYOOCkLtY9AJiD8GECjknxhYbEABDfUjp8BDtI0RYksRE9ACC+pXT4SFRko9AwHDoAxKeUDB+umg1qOAAAsF5KhY9kqY6nSUNg1HQAQGJIqfABmImoAwCRIXwAAABLpXT4oEtmcorWaqWmAwDMkdLhIxLxcACinSwAIJGlZPjg4A0AQOykVPjwrY43q6ut1V12uVoUGKESABJDSoUPAAAQe4QPAABgqZQOH4na24XLCx2zarWyHgAgMikdPpCcbFEay5bh+AHAHIQPAABgqZQKH75nxIl6JpugV4uizndtJujqBYCkl1LhwwyJGlgAAIgXhA8AAGCplA4fwXq7hFu3YXVdCJUvAIBEltLhA8nJsq62cXGnHwBIPCkZPhK95oAGpwCARJZS4YODNroiwTMrAMSNlAofvui5klxYnQCQGFI6fCQqDrIAgESW0uEjUe/tgo6xVgEgvkUlfOzYsUPf+ta3VFBQoG7dumncuHFau3ZtNGYFAAASTLrZH7h//35NmTJF06dP14svvqjCwkJ98cUX6tGjh9mzilhXukjGwxUPKmw6wRcEAHHN9PBxzz33qKysTI888oj7uf79+wedvrGxUY2Nje7H9fX1ZhfJLdRDEm0qEAq2EwCIjOmXXZ577jlNnDhR559/vgoLCzV+/Hj98Y9/DDp9VVWVnE6n+6+srMzsIkUdB6H44FujxWoBgPhkevj48ssv9dBDD2nIkCF6+eWXdeWVV+raa6/VY489FnD6pUuXqq6uzv1XXV1tdpGSDmEnNvjeAcAcpl92aWtr08SJE3XXXXdJksaPH6+NGzfqoYce0mWXXeY3vcPhkMPhMLsYAAAgTple81FSUqKRI0d6PTdixAht377d7FkBAIAEZHr4mDJlijZv3uz13Keffqp+/fqZPauIJXr1OZ05OsbXAwDxzfTw8cMf/lBvv/227rrrLn3++ed6/PHH9fDDD+vqq682e1ZhY1AxAABiz/TwceKJJ+qZZ57RE088oYqKCv30pz/Vfffdp0svvdTsWaWsRK+5iRarvxdWAwBExvQGp5I0f/58zZ8/PxofHXsccQAA6JKUvrcLEB6SJwCYgfCBpEPTHgCIbykZPsw/f7X2jJiDKwAgkaVU+OCYnRpYzwAQ31IqfCQLersAABIZ4QNJg0wGAImB8IGkZUS7iogqKACICOEDAABYKiXDR1fOiI04qNynt0tsUNEBAOZIrfCRJAdtDoId4x4+ABDfUit8AACAmEvp8MH5cZKhSggAEkJKhw+zDlUc8wAACF1Khw8kJ6tqtMicABCZlAwfiX7QoD0lACCRpVT4SJZjNpd5OkY4A4D4llLhA+gKMh8AmCOlw0ckJ8jUOsQvVg0AJIaUDh8AAMB6KR0+OFNObqxfAIhPKRk+uHQCAEDspFT44J4fMBMhFgAik1LhI1o4BsUXW9J0qgaA5JTS4YNDVHKJdk0ENR0AYI6UDh8AAMB6KR0+EvVElqYrAIBEltLhI1FR/d8JwhkAxLUUDR+RH7058AMA0DUpFT64XJEarFrNRsJeuAOA2Eqp8OGLLAIAgPVSOnwguRhcEwOAhED4MAHHvNTAZRYAMEdKhw8OJcmNUAgA8SklwwcHJQAAYielwgcNTAEAiL2UCh++CCPJiS7VABDfUjp8RIIrNvHL6nXD5TsAiAzhAwAAWIrwAQAALBX18FFVVSWbzabrr78+2rMKmeHzL5KLLUqtebjMAgDmiGr4eO+99/Twww9rzJgx0ZxNyGy0RAQAIOaiFj4OHjyoSy+9VH/84x/Vs2fPaM2mS8yKIgzrHV/ImAAQ36IWPq6++mrNmzdPs2bN6nC6xsZG1dfXe/0BkSADAkBiSI/Ghz755JNat26d3nvvvU6nraqq0k9+8pNoFAMAAMQh02s+qqurdd111+kvf/mLsrKyOp1+6dKlqqurc/9VV1ebXSQgKqhoAYDImF7zsXbtWtXW1mrChAnu51pbW/XGG2/ogQceUGNjo+x2u/s1h8Mhh8NhdjE65Kqej+TgQfsOAAC6xvTwMXPmTH300Udez11++eUaPny4brrpJq/gYTXaIaIryJ0AYA7Tw0dubq4qKiq8nsvJyVFBQYHf87FGGAEAwHqMcIqkQ1dbAIhvUent4mvlypVWzAYpjqsiAJAYqPkAAACWSsnwYZh8jswZd3yJ1r1dfNEAFQAik1Lhg7YAAADEXkqFj2TBCTcAIJERPsLEgT/+RauGy+zLdQCQqggfCYirR4Ex+iwAJAbCBwAAsFRKhg9OkAEAiJ0UCx9csAAAINZSLHwg1USzHQgNUAEgMoQPAABgKcKHCWhDAgBA6AgfQIgImQBgjpQMH105iHAAAgCga1IqfCTLvV3IPx2zJcuKBoAklVLhAwAAxB7hIwFxXh8nqIICgIgQPpB0CGcAEN8IH0gaNAYGgMSQkuGDkSkBAIidlAofyVIdT3QCACSylAof0UJNCgAAoSN8JKBkqcEBAKQmwkfYqOVIJDRCBYD4Q/hA0nBd/rJqgFNyDQBEJiXDR6KfDSd48QEAKS6lwge3/AAAIPZSKnz4IYwkpWit1kSvMQOAeJHa4SNBDyZkJgBAIkvt8AEAACxH+DBDgtagJBvXZREbjXsAIK4RPhIQWSc+GDQCAYCIpFT4sJnQWoLjDQAAXZNS4cMPtfMAAFgutcNHgiIzAQASWWqHDy6hIAzcvRgAzJHa4SNBcQgMLND3wncFAPEnJcMHjUaTG5elACC+pVT4YPgHAABiz/TwUVVVpRNPPFG5ubkqLCzUOeeco82bN5s9G3MQRpKSVSGTGjQAiIzp4eP111/X1VdfrbffflvLly9XS0uLZs+erUOHDpk9q7hh9TGIzAQASGTpZn/gSy+95PX4kUceUWFhodauXatTTz3V7Nl1TQSpgZNdAAC6xvTw4auurk6SlJ+fH/D1xsZGNTY2uh/X19dHu0gJjwAUG1xmAQBzRLXBqWEYWrJkiaZOnaqKioqA01RVVcnpdLr/ysrKolkkJLHj4YALUwAQz6IaPhYvXqwPP/xQTzzxRNBpli5dqrq6OvdfdXV1NIskicGiAACIpahddrnmmmv03HPP6Y033lDfvn2DTudwOORwOKJVDC9+58OcIAMAYDnTw4dhGLrmmmv0zDPPaOXKlRowYIDZs0h5ZKb4QP0ZAETG9PBx9dVX6/HHH9c///lP5ebmqqamRpLkdDqVnZ1t9uwAAECCMb3Nx0MPPaS6ujpNmzZNJSUl7r+//e1vZs+q6xL01DVBiw0AgKQoXXYBYoGGxACQGFLq3i4uXclHgd5L3oovnsOrmxmGWc0AYI6UCh8235t+JGjLzQQtNgAAklIsfCA1EM4AIL4RPhIQ1f8AgESW2uGDozi6gLY+ABCZ1A4fSCqEAQBIDCkZPjhGJTffdsUAgPiSkuHDLUEPUglabAAAJKV6+ADCwAB6AGAOwkcC4hAIAEhkhI8wBRrCm2G9AQAIXWqHDzIDuoDQCQCRScnwwbV7AABiJ6XCh18XzATtNpKgxbaMzeMbImYCQPxJqfCRLDigAgASGeEDSSdag4wR+gDAHIQPAABgKZsRZ60v6+vr5XQ6VVdXp7y8PFM/u//Nz7v//43xffTM+ztM/XyXyoEFGl6Sqw+/qtPabfvdzw/slaNJA/L15HvVkqTJgwq0uaZBZ40rlSS98NEuje7jVK/uDj33wU6NKs3Te1vb35+Tadehplb3Z10+pb/qj7ToqXVfSZLG9HXqaHOrpgzu5VWWz2sP6suvD2n2qCL3c0+v26ET++ersaVV2/cd1ozhhZKko81teuLd7ZpbUaxiZ5b+9cEujSvrobL8bL9l/HhXvbbtPawzKoqDfg+f1x7UO1v26ZJJ5bLZpNqGRr32ca0uPLFMTa1tevyd7ZKkij55+rTmoM6oKFZB98yQvuNXNu7WKUN6KTvTLkmqqTuqFzfUSJLmVhS7/9+nR7aGF+eqvKCbXtpQI2d2hioHFeiTXQ3q0S1DRXlZWrm5VtOGFWrHgSPauKNOcyqK9UH1ARmS3t9+QJKUn5OpfYea/MrRv6CbTh5YoFc/rtWIklwN6t1dT6/7SkeaW2Wz2dTU0haw/KcM6aU3P9sjZ3aG6o40u8u648ARdcu0y26z6WhLq5pb23+eA3vl6Ms9h0L6bgIpcWZpdB+nXtm0W5I0Y3ihDhxu0pd7Dukb4/to/6EmPbt+p2YML9Rrn9S635edYdf8MSU62NiiNz/bo/Mm9NW/PtipvYeadPrIIr2//YD2HGzUyQPztWXPIe2ub5QkDS3qrm6Z6dq295AONbZqUGF3fbyrXt8Y30ef1TYo056msWU9JElb9hzSnoONOrF/viRp3bHfzAn9ekqS2toMPffBTp1RUSKp/Xdy1thSpdttWl99QL27O1Tb0KiGo806dWhvSdKXXx/SkaZWjSzN0z/WfqXThvbWpl316p3rUM9uGdqwo97rN+Hy6se7Nbw4T317tm/zLa2G/rl+h+aNKVFWhl27DhzV6i/36twT+khq38Y/3d2gM0e3l23d9gOq3ndYpw3trRc37NJ5E/oqw56mllZDz3+0S3MrirXzwBHtqjuqykEFXvNeu22/jjS1auqQXvp4V732HmzS1CHev2eXQL9rT0eaWvVZ7UGN6esM+Hpza5ueW79T88eWypHufQ6671CTXt5Yo9OG9tbLG3frpAH5WrNtvxae3M9dq7j/UJPe3bJPcwL8/ptb2/Tyxt2aN7qkw1rIw42teu6DncpxpGt8eQ/3dy6136fp8Xe3a3xZD727dZ9mDi9y74da2wyl2Wzuz25sad9vzR5ZpNIe/vsqX4W5WWo42qwjze3705c2tC9rVoZdG3fWqaLP8e/sz6u2yjDa97eStLmmQfk5merRLUN/eXu7+vbM1ukj29dB/ZEW1R9t9loO17K8tKFGp48sUrr9+Bey71CTqvcd1tiyHjIM6cUNuzRnVLEajrboxQ3t2/iz7+/U/LEl+qL2oMryuyk9zaZn1+9UeX43FedlaVSfPB1ubNXzH+3SOeNLlWFP0wfVB9RmSKP7OPXXd7ZpxvBCNRxt0Xtb96nt2NH+jFHF+o9TBrh/c2YJ5/idsuEDyeu8CX31j7VfxboYABC3Bhd216tLTjP1M8M5fqebOme4fe/UgXr4jS9DmnZoUXc1tbRp697DIX/+1dMH6XcrvvB7/hvj+6i0R5b7sWuaE8p7qHJQgf76znYdONzs9Z5Th/bW6D55Xp/nOgt3zcuTYUgPrmyftnJggU7o1yNgGV2f58zO0LdOLvf6/OnDemvF5q8DLldnPD/n6umDtH3fEf3rg52S2msovnPKAL/wMW9MiZ7/cJckaUK/nl41Ur4KcjK1N0AtRyiyM+zuM6pEMa6sh9ZXH7B8vhdPKleG3abHVm+TJM0cXqiC7pn67zXt6+78CX1VmOcIuJ1L0tTBvfTW53u8njtvQl+1GYaeXtd5rebA3jma63Hm/uqmWm3e3SDp+Hbou625Hnd3pGvR5H7ux2P7OjV1SK+AZQ32W50+rLdGlrbvoA8ebdGjx74Hz2113ugS9e/Vze+9rs9Ls0k/mOb9m2luNdz7nj49snXO+NKg7/dc1kCvecqw2/S9Uwd6TZOdYdcVU/uH/Nkdzcdz2kD7Kd/vcfKgAo0v7xHy/Hzn6ap9DOTq6YO0fNNufbr7oCSp1JmlPj2z3TXRnqYO7qXcrHR3bevYsh6aOvh4rVag8tUdadZf3m6v+R1f3sNdwxquiyeV64l3t7sfh3PidaixJaJ5moXwEYFffHOM5owq1q3PfqT/ObaT8LXk9KEBw0emPU1Nrd5V8fPHlKruSLP+660tIc0/056mG+cMD7iTuPSkck30qEpzTTN/TKmumDpAu+qO+u2Yzxpbeqw6fZe272sPQNOH93b/OG6cM9xresMw3OHjGyf00QUTywKW0zXvs8aW6sY5w/Xvj2v1SU2Drp05REtOH6qn1n6lG/7+gdd7fOcVyDUzhujNz/ZoXFkP9c51aNXne9zh49oZg1WQ4/B7zxVTBrh36IF4rpfZo4r0xLvVnZYjkFOH9tLLG3eH/b6LJ5VFPM+uumRSeYfh4/unDtTLG2u0de9hOdLT1BjkUlK4vnvKAGVn2t3hY/7YEg0rynOHj29P6a9Rpc6A23maTZo5otAvfHx7cn81t7aFFD6mDS302t6aWw13+HA97zlvz9/caUN7ez1eMLZU3zlloF9ZC3MdQX+rZ44u0fnHfju76o64w8cFE8vc2+q5J/TRzBH+l1Zcn3f2uD5+v5mmljb3vqdfQbeAvynf5Qr2mqd5o0v8vpdJA/I7fH9Hv2ff+XhOu/9ws/uyrOfrnu/5/mmDdNrQ3lrxydfatKu+0/n5zvO8CX31Re1B7aw76jVNQU6mbpwzXG2G3OFjyuBeKsvvFjB8zBpRqJIe2e7wcfJA7+8k0Pexfe9h9/715IEFEYeP75wywB0+Muw2XVbZzx0+Ah1rPLXF+KIHDU4jcNLAfDm7Zei+C8dpRIl/1dI/rqxUWpCLnYGe7nas3UKoOrqOmpYWflcP1zs8R+xs62C7tHkUIJS5uSa/94JxWjx9sL57yoCwy+gpK8Ou00cWqXdue8hItx/fjO1pNq/lWHhyP/3fb0/0en/9Ee8zKknK9Lju3adHtv5z/sgulTEcG38yR8vOGmXZ/MIxsHeObjpjuH578Qm6ZsZgXTtziGmfnZ6WpvS04997ms0mu8f2a+9gW05PSwv4G0u32zp8X0faOtroffjOOtjvPdjz7Z9hCzhdRoTld7/fo13BmgAHS0lKj2AegfYtUetZFsKB8bRj7XvSIjiKFedl6fQgbUROOdbOptVnewi2Xfk+nxFCgTy/N3sXvkTP7cZms/k87vi9YWzuUUH4iIDrd5FuT9PEY43iPE3snx90Qw20vm02W1gDh3W0c41kM3b9Vjx/79EIxSNL8/SjOcOUm5Uhybwdl2cjrrQ0m1fZfzR7mGYML+p0Xp47uwG9uuuKqQPcjRejLceRLke6Xf+4slK/PG+MJfP00sF306dHttLSbBrd16kbZg/TZZX9vF73fRyOtDTvA6XNZpNHjuxwp2xPswU8GAYLJaEIZ2ds85lHsJ9kqMd4z4/zDNOd/Q4DHaQ9yxbszDeSn3eg77V/QU7Q6X0bsoajLYzKtfD2nu1+fMYwdctM181zh2t4ca5+8c3jv7sxfXtIam846ylYYPPdDj33R8F4fpWRnDC62L0CrM/ndvI7iHVzT8JHF/1ozrCAz4ezPYW77UW6cw3G9eP1Dh/mbZhml9eX55mG3eYdPgLtlwIVZ7hHDZYr3HXxBDRsE/vna9IAc1ufh6KjxfRdd7lZGfpw2WxddGKZnvjuybp25hCdP6Gv/n5lpbZUnRnWfNPT0nwOtIbfmVzw99oCrp+MrtR8hLHN+84i2AGko2Xw/I15LrfnwauzEkX6K+0VYq+y8yf0df/fcxH/dNlEfWN8H101zb+NxbUzBkuSbgyybwxFV9ZFOCb2z9dL15+qC048funYtSr8woc98OHS7nPymBFkOk+e67tLNR8+Yd1z2+/8hCvi2ZqC8BEBz3XmzM7QpSeV+00TbKczqHd3r8dDCru7r/uGyuyDYqCiWrFhRqPmQ/K+fOT6rjqb1cT+x2uwXO+JdmjynJdLrKtCfQX6CvKyMnT3N8eoclCBenV36Jfnj9WJ/fM7PNAGYk+zedV8HG1uDfmyixR4/fheuglHOAc8vzs1BLvsEuIe1it8eJS/szJF+jsdVhy8J4Izu71mcm5FsX55/lj38wXdj7elmjWySL++cJwK87L83r9k9jCtuW2WvnPKwMgKp/B+B5HUHHT0vbk+be9B70bnHdV81DY0uh9nhhA+vC67dOEonOZV82Hze9wR2nwkgVBX4QvXnqI/fGuC+7E9zablS05Td0d47X67Uk0XSKAdpxUbZiTVpYEM6HW86vdIc6vXjivUA2KgH63rkkI0M4jvDiJYjVMsakQicfEk7yDteYZ96tDeXpeV7Gk2OdKPt3dqONoS8hlhm2EEfD07025RzUdol11C3cY9p/IsfyyODw9eeoJOG9pbS+eOkCTdf9E4zRpRGLCWI5he3f0bfYfD83cwfVhv/deiiUGnNfvn6dq/+u5ng21X6Wk27ao74n4cbOwVr3l4bueRNFoJUCabzXs77Ox7ifWJDr1dIuB7gAj1EoWrW11XmX1G7tpgPZfDzA0z2hUInteWW1oNrx9gqMchr/cc+7hpwwr15o+na8eBI7ro4bdNKKk/1+BULrHeIfgKd1v72Tmj9R9TB+p7j61RdqZd/1o8VbUNjXJmZyg7064vvz7ontZ3Z56Znub1XEf75NF9nQG3K7vNFnE1dljfve9ll6ANTjv4iCBnqeleC279BjFlcC+vwQrPHtdHZ4/rY/p8zh3fR08HGejRMwg+cvmkDj/H1YYsHB19q679ief+MDcrQz26BZ6P3aedWb8g7WDSfYLC8fd3Xt5gfNuOhNfgNLY7G8KHCYKtw8un9Ne/PtilgpxM3Xxmx13APDeUWSMK9erHtUGn9d2h2WxdO0Nyt/nweM4IcacXSs1CsLM/s0KJZxla2gwV52W1j0iZble3zHS/aQJ9V8HaGpTldwvYIn54ca4+qWmIuMxL5w5XXnaGFoz1HoMhaJCN4n6io3UY7iqyp9k0uLC7Xvnhqe2t79NsKnYer5rvX5Cj04b2VvesdOVlta+bG04fqlc/3q1zxvfR4cZWr88KxreK2f18WuSXXcJp5xRqzUeo4c3mcQDy/KzOAlGcZdWw3DpvhHbWHdHbX+7zey2cIPizcyp05V/W6rthXOYZX97D77nrZg7Rqi/2uIOWZ6PXy6f0V2GeQz89e5RKe2Tr2ifed484nWazhbQeXCP6St77xGDbSK4jXUvPHKHhJbn68T8+1PiyHvq7zxgenkHb7nvZpZPfQazbfBA+1Hl/aF++6yxYgrxjwSjdsSB4F0rPYXgvmFim//u/WzVzeKF+c/F4ffhVnS74w+qA7/PdWO02m1qOlaFnt44bkgUKAoG20VhvmJGy2doPpr+75IQw3xd8ZxDoYPbS9afqhJ8u9xtyPdRq9oLuDp3n0ZjPJehON/rNTwLPNsL5Bmucl5Zm06NXeJ/JXjNziK451oX3qMcAba4da2Guw+uauuS9I/f6fJvcQ+6Hy7drZUd8v5ZwutYHEuyMNVF/h6Eo6O7Q9bOGBqxVDGe7K8vvpuevPSWkad+9daa+bmj0a3snST88fah+ePpQ92PP/XpZfvtAbwsr+0tq38Zc4SPHYQ+pFsFzkbwDpqFJA/L17pZ9GtPXqQ+/qpMkdc9K1yXH2hO6RiL1Cx9etSk+NR+dlIfeLknAcx3+/ludH/Tuv2icenTL0M/PGe1+bkhRrt67dZYe+tYEZWXYO7zG77ujs9na5/vzb1Sof6/gXd+CcR14o9XbxYJ2m/rmCX3Vq7tD88eUdDptoCXz7bIWikAHq1BrjILNI9j7pw8rDK1QEehoccNtRNpVnu2fuh37/51nV6i7I113nztaL11/im44faiuCzLeiD3Npl7dHbr73NG6ee5wDS3yP8gE05VLXpGM8+Hd28XzeY//d7I9Rfo7jVGW9ROsHD+aPUyFuQ79+AzvHjN/umyi8nMy/QJsqApzszSqNPD9bnx1tD14nuRNGdwr7Cooz+1iQr983X3uaH3v1IG694LjDXxDWbU2n/1WmlcNWmcNTkMvbzRQ8xEB343C86Hr5lcdOXtcH501ttRvx56fE1r3N99rj/k5mSHNNxhXMUIdZCzszzfvo4L6PxeMVVubEbSq0VXFLwXeYXu+LdDAcYHUBRisLFTB9gs5mYF/klkZabpt3gj97PmP3c+NKs3Txp31EZehs7JI1h+kumWm6+9XVsowjgeRMyqKNXtkkXvdDu+gp4Zrh3vRpPYzxt+99nkH03o/DnQTwO6OdB0MMAy132WXIKdxoV52CTZdp+N8hPTp8StYuC3L76Z3bpnp9/qskUVaO2KWJaG4o2DnWdPhSA+x5sMW+P/O7AwN7N1dt5w5IuwyevasqW1oTKg2HylV8+HbEv/2Y6NY/vrCcaroE3lj0EjWYSg/HtfdEn25Rt+86xujZU+z6WceNSiRcG2wd5/b3hPhxjnDTN2pBVtUs3cgHV3jHNi7u340e6iqzh2tO8+ukNQ+HsGsY0NXnzexr96//XS9ddP0gC31f+HRS+O0DgYfC+WyS5pNmjEs8Loty+8WcHyE+WNK3Xc/ltrv1XN7GKOwBmss1xmLKz4kSScGGO8k0LodW+aUw6eRqm95PdvrFORkqnJggeaPKZEjPc2vi/uXew7K17KzRslmk26b531g8J1PS2vgX0yHwS6ELzfRw0VnIvl+rKqN6+jg7HcCGuaK8lyGcNoo/eTYSMj9C7rptnkjvC4xji3rEfI4OVLsL+mlVM1H1bljvO6f8R9TB+iSSeXKzrTr/7291f18r+4O7TnYGOATXCLr7RKuhxdO0IClL7gf3zx3uBZV9ndvcJecVK5vjO8T8TVuF9cmOn14oT6+8wxlZ9p19ePruvSZXp8fiyNYAItnHK+qdy2nYRhqbGlTVkb7d9gzSO3TBRPLtGBMqWy2ro3cKEmb7jzDPb9Arp4+WFdNG6TGljYZRvsO2jX9Jz89Q1L7GU9amk0f33mGtuw5pDN/82aH83z3llkaetuLAV/ruOYjPtZdIIMLc7XmtlnaceCIzrivffl9e7rcc94YLX58nW6bN1LThvVWhj1NaTbpUFOrXxf3QF0ez5vQV3NGFfn1qPDdpoP1uOho28/22AaCt/lI7vgRv1uXFCRPSvIPJqGsJc/fkldvlzDaCy2a3F8XTCwLuM9PT7OpMNehKYML1NJqyJmdoVc2Bb/P1Mobp4VQ6uhJqZqPQFwr0fsyQ3g/+GjtHnx3XFnpaX4bXbjBY0zf9uuduR6XITzva+L6vMbm0BrghrLziMcdjGs5bTZbh0HA9z1ZGfaIwpRnbUYo83OVyzVPz/dmZdjdNQHZmXaNLM3TWWP971zqKTPCwBQnuTGo3KwMn/Y63gUeV9ZDb900Q2dUFCsro30MEJvNFnBsndYgY3oHCha+30vQAagCPP2j2UM1Z1SRZgwv7HA6KYSz0+TOJjF1xZT+kuS1nlyun9XeMPWbJ7Q3Gg/pEobHOg7n8oivYPt8+7HeZX/9zsn62/cr9bNzKnT6yCI9esUkXT/Lv41UoF58Vkqpmo8OeWw7nXZv83k9mtfOpg3rrZXHbj0f6kGyIxeeWKbahqM6dUhvXXislXlhnv9lhn2HOqr5CVOcH8Cs8B9TB+hIU6umB9iRmeH/XDBW/Qq6qWe3TN35P5sktd9p1XW330jFe/iQ2i+pDSvKlbNbRpfKG+zSSSC+YSGcqnPPGrjjnxekzUeU0kW8rNd4KUcg04YVavXSGSrM9R/F9ZzxfTRpQL6Kj43w2pVDQLBtJ9wxdnwnL8zL0h8vax+c7bShvXXfq59FVL5oIXwc493YMrwtaf6YUv1z/U6VH+uOZaZHvn2ifvva51r9xV6dMz78gX5GlOTp4131mnrsTo1ZGXbdOGe4Wjy6Fgc6s/MceTJa4ni/E5Fgl2NumzdCWRn2oPcBMkOGPU03zB6mDTvq3M/d883R2l13VLNGRh544uWSWUfsaTa9eN0p7m7WkWoJo5V1kc8BKVh7owOHQ2uU7FnsIo8hy3tkd9wIPVrhxDrxvX2VOIPXDnSl5sCzp5xvyLissp8eW71N184cHNZnWnE7CDMRPo7x3O94Zo/7Lxqn655c7zWt78991ohC/WvxVA3oHX43187YbDZdO3NIxLcy/+t3TlJN3VENLcr1ej7dnqZbzhyuI01t6hPgR9QaYgALZXsPdZCxc8Z1fOkgXg0u7K7fXjxeJc4s3fzUR+7n314602uALSt4rrZumen67ysrO32PTbaAY2m0v5YYzLjlQCjjfPzm4vFa/cVe/cBnqHHXpZ81t83SvkNNmv3rNyRJA332CYOC7CNsNptW3TxDTS1tys3K0C/PG6ONO+s7bNwsBT/jnjOqSC9v3K15IXQ9j6UEO14GFe44H90d6crJtKulzfC7yd8tZ47QOeP7aNyxu+uGKtLB9WIl5cLHrBFF7aMp+hzozhhVrLXb9qvUmaU5FcV65H+3akK/njp5YIHfZ/T26Q1hs7Xfcjwe5edkBu3C+71Tg9+rIdQBl0LplnrSwM7vS/LBHbO9usMmgsGF3fV57UEtGFPq/h48d6ZWB4/O5hmsIbXNJj191WT9c/1O/fLlzV6vTYvi+CLxZsGYEv3mtc81vDg36DRnjS0N2L6mf6/2Ws9e3R1evaVctWH9C7pp697DOm9C8JtIep5Jnz+xTOeHvQTHLTtrlEaVOnXhiYHnFy+HqXgpR1dNHlSgx1ZvC/iaK9jPGVXsfs6eZtPa20+X5D8gX1aGXSeU9wy7DKHeqVgKfTiBaEqsvb0J7r9onN78bI/fGcXlU/qrf68cnVDeQ92z0nXywAJVDipQXlaGZg4v1L8/qdX9F41TWX63oD0ikkln4WPFj6ZpV92RDjfi/715hj7d3aBpQc7eJvZrDyVptuN30kwkf/9+pd7bus+rHceiyf314oaakAY7i4beuQ499YPJynH4XzZ76fpTdMHvV+vLPYf8Xuvbs5uunj7YL3ycG8GlvkS1eMYQjerj1Elh3MTvlR+eqrojzerb0/uS66T++Xp36z5delL7zQmfvmqK1mzdF7DxYlcEO+EucWZHXFtqpUS4rBeKOaOK9ci3T9TwEv/g+uJ1p2jd9gN+696MNnxS+wCTf31nu26d13HX+19fOFb/WPuVvjG+r2aNiP1Jhc2Is75c9fX1cjqdqqurU15e7NNZqvrFS5/owZVfKDvDro+Pde+Mhp0Hjig3Kz2im0PFqy17Dqm0R5Yl7WbCdaixRb96ZbPmjS7Reb9vH77/n1dPcQ9XftovV2jb3sOS2keTnBVkrBl0rKmlTTsPHIloxOFQ9L/5eUnt7YkiuXX9Qyu/0D0vfSJJ2nr3PFPLFo6dB45o8t2vxbwcMEc4x++ohY8HH3xQv/zlL7Vr1y6NGjVK9913n045pfPx9wkf8eFoc6v+sfYrnTa0t/u+Bkgu72/fr+37DnvdsXR3/VG9srFG88eUpkQNX6LasueQVn+xV+dP7KuMCG6L2tTSpr+vrdaUQb2iFpBC9fLGGuVlZahykP8lbiSWmIePv/3tb1q4cKEefPBBTZkyRX/4wx/0pz/9SZs2bVJ5eXmH7yV8AACQeGIePk466SSdcMIJeuihh9zPjRgxQuecc46qqqo6fC/hAwCAxBPO8dv0EU6bmpq0du1azZ492+v52bNna9WqVX7TNzY2qr6+3usPAAAkL9PDx549e9Ta2qqiIu+GakVFRaqpqfGbvqqqSk6n0/1XVha8KxoAAEh8Ubu3i28XKsMwAnarWrp0qerq6tx/1dXVftMAAIDkYfo4H7169ZLdbver5aitrfWrDZEkh8Mhh8P/3iIAACA5mV7zkZmZqQkTJmj58uVezy9fvlyTJ082e3YAACDBRGWE0yVLlmjhwoWaOHGiKisr9fDDD2v79u268sorozE7AACQQKISPi688ELt3btXd955p3bt2qWKigq98MIL6tevXzRmBwAAEgjDqwMAgC6L6TgfAAAAHSF8AAAASxE+AACApQgfAADAUlHp7dIVrvav3OMFAIDE4Tpuh9KPJe7CR0NDgyRxjxcAABJQQ0ODnE5nh9PEXVfbtrY27dy5U7m5uQHvBdMV9fX1KisrU3V1dcp042WZWeZkxTKzzMkqUZfZMAw1NDSotLRUaWkdt+qIu5qPtLQ09e3bN6rzyMvLS6gVagaWOTWwzKmBZU4NibjMndV4uNDgFAAAWIrwAQAALJVS4cPhcOiOO+6Qw+GIdVEswzKnBpY5NbDMqSEVljnuGpwCAIDkllI1HwAAIPYIHwAAwFKEDwAAYCnCBwAAsBThAwAAWCplwseDDz6oAQMGKCsrSxMmTNCbb74Z6yKFZNmyZbLZbF5/xcXF7tcNw9CyZctUWlqq7OxsTZs2TRs3bvT6jMbGRl1zzTXq1auXcnJydNZZZ+mrr77ymmb//v1auHChnE6nnE6nFi5cqAMHDlixiHrjjTe0YMEClZaWymaz6dlnn/V63cpl3L59uxYsWKCcnBz16tVL1157rZqamixf5m9/+9t+6/3kk09O6GWuqqrSiSeeqNzcXBUWFuqcc87R5s2bvaZJtnUdyjIn27p+6KGHNGbMGPfonJWVlXrxxRfdryfbOg5lmZNtHZvCSAFPPvmkkZGRYfzxj380Nm3aZFx33XVGTk6OsW3btlgXrVN33HGHMWrUKGPXrl3uv9raWvfrd999t5Gbm2s89dRTxkcffWRceOGFRklJiVFfX++e5sorrzT69OljLF++3Fi3bp0xffp0Y+zYsUZLS4t7mjPOOMOoqKgwVq1aZaxatcqoqKgw5s+fb8kyvvDCC8att95qPPXUU4Yk45lnnvF63aplbGlpMSoqKozp06cb69atM5YvX26UlpYaixcvtnyZFy1aZJxxxhle633v3r1e0yTaMs+ZM8d45JFHjA0bNhjr16835s2bZ5SXlxsHDx50T5Ns6zqUZU62df3cc88Zzz//vLF582Zj8+bNxi233GJkZGQYGzZsMAwj+dZxKMucbOvYDCkRPiZNmmRceeWVXs8NHz7cuPnmm2NUotDdcccdxtixYwO+1tbWZhQXFxt33323+7mjR48aTqfT+P3vf28YhmEcOHDAyMjIMJ588kn3NDt27DDS0tKMl156yTAMw9i0aZMhyXj77bfd06xevdqQZHzyySdRWKrgfA/EVi7jCy+8YKSlpRk7duxwT/PEE08YDofDqKuri8ryGob/MhtG+87q7LPPDvqeRF9mwzCM2tpaQ5Lx+uuvG4aRGuvad5kNIzXWdc+ePY0//elPKbGOXVzLbBipsY7DlfSXXZqamrR27VrNnj3b6/nZs2dr1apVMSpVeD777DOVlpZqwIABuuiii/Tll19KkrZs2aKamhqvZXM4HDrttNPcy7Z27Vo1Nzd7TVNaWqqKigr3NKtXr5bT6dRJJ53knubkk0+W0+mM+Xdk5TKuXr1aFRUVKi0tdU8zZ84cNTY2au3atVFdzkBWrlypwsJCDR06VN/97ndVW1vrfi0Zlrmurk6SlJ+fLyk11rXvMrsk67pubW3Vk08+qUOHDqmysjIl1rHvMrsk6zqOVNzd1dZse/bsUWtrq4qKiryeLyoqUk1NTYxKFbqTTjpJjz32mIYOHardu3frZz/7mSZPnqyNGze6yx9o2bZt2yZJqqmpUWZmpnr27Ok3jev9NTU1Kiws9Jt3YWFhzL8jK5expqbGbz49e/ZUZmam5d/D3Llzdf7556tfv37asmWLbr/9ds2YMUNr166Vw+FI+GU2DENLlizR1KlTVVFR4S6Laxk8Jcu6DrTMUnKu648++kiVlZU6evSounfvrmeeeUYjR450HySTcR0HW2YpOddxVyV9+HCx2Wxejw3D8HsuHs2dO9f9/9GjR6uyslKDBg3So48+6m6wFMmy+U4TaPp4+o6sWsZ4+R4uvPBC9/8rKio0ceJE9evXT88//7zOPffcoO9LlGVevHixPvzwQ7311lt+ryXrug62zMm4rocNG6b169frwIEDeuqpp7Ro0SK9/vrrQcuRDOs42DKPHDkyKddxVyX9ZZdevXrJbrf7pb7a2lq/hJgIcnJyNHr0aH322WfuXi8dLVtxcbGampq0f//+DqfZvXu337y+/vrrmH9HVi5jcXGx33z279+v5ubmmH8PJSUl6tevnz777DNJib3M11xzjZ577jmtWLFCffv2dT+fzOs62DIHkgzrOjMzU4MHD9bEiRNVVVWlsWPH6v7770/qdRxsmQNJhnXcVUkfPjIzMzVhwgQtX77c6/nly5dr8uTJMSpV5BobG/Xxxx+rpKREAwYMUHFxsdeyNTU16fXXX3cv24QJE5SRkeE1za5du7Rhwwb3NJWVlaqrq9O7777rnuadd95RXV1dzL8jK5exsrJSGzZs0K5du9zTvPLKK3I4HJowYUJUl7Mze/fuVXV1tUpKSiQl5jIbhqHFixfr6aef1muvvaYBAwZ4vZ6M67qzZQ4kGda1L8Mw1NjYmJTrOBjXMgeSjOs4bBY0ao05V1fb//qv/zI2bdpkXH/99UZOTo6xdevWWBetUzfccIOxcuVK48svvzTefvttY/78+UZubq677HfffbfhdDqNp59+2vjoo4+Miy++OGC3tb59+xqvvvqqsW7dOmPGjBkBu3CNGTPGWL16tbF69Wpj9OjRlnW1bWhoMN5//33j/fffNyQZ9957r/H++++7u0JbtYyubmozZ8401q1bZ7z66qtG3759o9JNraNlbmhoMG644QZj1apVxpYtW4wVK1YYlZWVRp8+fRJ6mX/wgx8YTqfTWLlypVeXw8OHD7unSbZ13dkyJ+O6Xrp0qfHGG28YW7ZsMT788EPjlltuMdLS0oxXXnnFMIzkW8edLXMyrmMzpET4MAzD+N3vfmf069fPyMzMNE444QSvrm7xzNUHPiMjwygtLTXOPfdcY+PGje7X29rajDvuuMMoLi42HA6HceqppxofffSR12ccOXLEWLx4sZGfn29kZ2cb8+fPN7Zv3+41zd69e41LL73UyM3NNXJzc41LL73U2L9/vxWLaKxYscKQ5Pe3aNEiy5dx27Ztxrx584zs7GwjPz/fWLx4sXH06FFLl/nw4cPG7Nmzjd69exsZGRlGeXm5sWjRIr/lSbRlDrS8koxHHnnEPU2yrevOljkZ1/UVV1zh3tf27t3bmDlzpjt4GEbyrePOljkZ17EZbIZhGNbVswAAgFSX9G0+AABAfCF8AAAASxE+AACApQgfAADAUoQPAABgKcIHAACwFOEDAABYivABAAAsRfgAAACWInwAAABLET4AAICl/j9obnYYI6pl/wAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGeCAYAAAA0WWMxAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOCpJREFUeJzt3Qd8FHX+//FPIBBqQocAoUiVXkXAAicHIhbs+kNFPBURC4eHyinW09j+nuU4LHeK97Nw6E8UPYHzkKYHKiAIFoq0SAchoQZI5v/4fGWX2WV32SW7k92Z1/PxWMJuJrvTduY93zZplmVZAgAA4JAyTn0QAAAA4QMAADiOkg8AAOAowgcAAHAU4QMAADiK8AEAABxF+AAAAI4ifAAAAEcRPgAAgKPSJckUFxfLpk2bpGrVqpKWllbaswMAAKKgA6bv2bNH6tevL2XKnKBsw4rRnDlzrPPPP9/Kzs7WYdmtKVOmhJ12+PDhZpo///nPUb9/Xl6e+RserAP2AfYB9gH2AfYBSbl1oOfxE4m55GPfvn3SsWNHueGGG+SSSy4JO92UKVNkwYIFJgHFQks8VF5enmRmZsY6ewAAoBQUFBRITk6O/zweSczhY+DAgeYRycaNG+X222+XGTNmyKBBg2J6f19ViwYPwgcAAKklmiYT6Ylos3HttdfKmDFjpG3btiecvrCw0DzsyQkAALhX3Hu7PPnkk5Keni533HFHVNPn5uZKVlaW/6FFNgAAwL3iGj4WLVokzz//vEycODHqnipjx46V/Px8/0PbegAAAPeKa/iYN2+ebNu2TRo1amRKP/Sxfv16ueuuu6RJkyYh/yYjI8PfvoN2HgAAuF9c23xoW49+/foFvDZgwADz+rBhw+L5UQAAwCvhY+/evbJ69Wr/87Vr18qSJUukRo0apsSjZs2aAdOXK1dO6tWrJ61atYrPHAMAAG+Fj4ULF0rfvn39z0ePHm1+Dh061LT1AAAAiGv46NOnjxlCNVrr1q2L9SMAAICLcWM5AADgKMIHAABwFOEDAAA4ivABAAAcRfiwmbdqu7w05yc5dKTY2a0AAICHxP3Gcqns2r9/ZX7Wy6wggzs3KO3ZAQDAlSj5CGFT/gHntwQAAB5B+AAAAI4ifAAAAEcRPgAAgKMIHyHs3HvI2a0AAICHED5C+Pvna6WoOPr71wAAgOgRPsI4eLgohtUIAACiRfgIoyiGO/cCAIDoET7CKCoifAAAkAiEjzAo+QAAIDEIH2EU0+AUAICEIHyEQckHAACJQfgIg4IPAAASg/ABAAAcRfgAAACOInwAAABHET4AAICjCB8AAMBRhA8AAOAowgcAAHAU4QMAADiK8AEAABxF+AAAAI4ifAAAAEcRPgAAgKMIHwAAwFGEDwAA4CjCBwAAcBThAwAAOIrwAQAAHEX4AAAAjiJ8AAAARxE+wrAsy9ktAQCAR8QcPubOnSsXXHCB1K9fX9LS0uSDDz7w/+7w4cNyzz33SPv27aVy5cpmmuuuu042bdoU7/kGAABeCR/79u2Tjh07yvjx44/73f79+2Xx4sUybtw48/P999+XFStWyIUXXhiv+QUAACkuPdY/GDhwoHmEkpWVJZ9++mnAa3/5y1/ktNNOkw0bNkijRo1Ofk4BAIA3w0es8vPzTfVMtWrVQv6+sLDQPHwKCgoSPUsAAMCtDU4PHjxo2oBcffXVkpmZGXKa3NxcU2Lie+Tk5CRylgAAgFvDhzY+veKKK0yvkQkTJoSdbuzYsaZ0xPfIy8tL1CwBAAC3Vrv4gsf69evls88+C1vqoTIyMswDAAB4Q3qigseqVatk1qxZUrNmzXh/BAAA8FL42Lt3r6xevdr/fO3atbJkyRKpUaOGZGdny2WXXWa62X788cdSVFQkW7ZsMdPp78uXLx/fuQcAAO4PHwsXLpS+ffv6n48ePdr8HDp0qDz00EMydepU87xTp04Bf6elIH369Cn5HAMAAG+FDw0QkYYeZ1hyAAAQCfd2AQAAjiJ8AAAARxE+AACAowgfAADAUYQPAADgKMIHAABwFOEDAAA4ivABAAAcRfgII8I4agAAoAQIHwAAwFGEDwAA4CjCBwAAcBThAwAAOIrwAQAAHEX4AAAAjiJ8AAAARxE+AACAowgfAADAUYQPAADgKMIHAABwFOEDAAA4ivABAAAcRfgAAACOInwAAABHET4AAICjCB8AAMBRhA8AAOAowgcAAHAU4QMAADiK8AEAABxF+HCJ+6Ysk0EvzJODh4tKe1YAAIiI8OESb325Qb7bVCCf/bittGcFAICICB8uQ8kHACDZET5c5kiRVdqzAABARIQPlzlSTPgAACQ3wofLFBUXl/YsAAAQEeHDZV6eu6a0ZwEAgIgIHy7z864Dsnv/odKeDQAAwiJ8uNChIqpeAADJi/DhElUz0kt7FgAASEz4mDt3rlxwwQVSv359SUtLkw8++CDg95ZlyQMPPCDZ2dlSsWJF6devn6xatSrWjwEAAC4Vc/jYt2+fdOzYUcaPHx/y90899ZS88MIL8tJLL8mXX34plStXlgEDBsjBgwfjMb8AACDFxVxWP3DgQPMIRUs9nnvuObn//vvloosuMq/94x//kLp165oSkquuukqSic7vl2t/kdb1qkq1SuVLe3YAAPCEuLb5WLt2rWzZssVUtfhkZWVJjx49ZP78+SH/prCwUAoKCgIeTvno281y1SsL5Ld/nuvYZwIA4HVxDR8aPJSWdNjpc9/vguXm5pqA4nvk5OSIU2Z89+s8bd9TKF6iyz3izUUyi5vQAQC82Ntl7Nixkp+f73/k5eWV9iylpFgGVb/t7cUybfkWGT15SQLnCAAAB8JHvXr1zM+tW7cGvK7Pfb8LlpGRIZmZmQEPJNbhozef27X/MKsaAJDa4aNp06YmZMycOdP/mrbh0F4vPXv2jOdHAQAAr/R22bt3r6xevTqgkemSJUukRo0a0qhRIxk1apT86U9/khYtWpgwMm7cODMmyODBg+M97wAAwAvhY+HChdK3b1//89GjR5ufQ4cOlYkTJ8rdd99txgK5+eabZffu3XLGGWfI9OnTpUKFCpJKLO5MDwBAcoSPPn36mPExwtFRTx955BHzAAAASLreLgAAwFsIHy4RqTQKAIBkQvgAAACOInwAAABHET4AAICjCB8AAMBRhA8AAOAowgcAAHAU4QMAADiK8OESjPIBAEgVhA8AAOAob4cPigsAAHCct8MHAABwHOEDAAA4ivABAAAcRfgAAACOIny4hGVvPEtDWgBAEiN8AAAARxE+wrAoPgAAICEIHwAAwFGEDwAA4CjCBwAAcBThAwAAOIrw4RI0kAUApArCBwAAcBThAwAAOIrwAQAAHJUuHvTynJ8kq2K50p4NAAA8yXPhY8PO/ZI77Ufz/3Pb1ivt2QEAwHM8Ez527C2U8bNWS93MCv7X6CECAIDzPBM+ft51QF7/Yl34O8GmODctCwDA3WhwCgAAHOWZ8FGjUvnSngUAAOCl8AEAAJID4QMAADjK0+GDNpoAADjP0+EDAAA4j/ABAAAc5ZnwkZbm7nEzUmx2AQAeFvfwUVRUJOPGjZOmTZtKxYoVpVmzZvLoo4+KlWpncwAAkBojnD755JMyYcIEeeONN6Rt27aycOFCGTZsmGRlZckdd9wR748DAABeDx///e9/5aKLLpJBgwaZ502aNJF33nlHvvrqK0lmlMwAAJCi1S69evWSmTNnysqVK83zpUuXyueffy4DBw4MOX1hYaEUFBQEPJxCTRAAAC4o+bj33ntNgGjdurWULVvWtAF57LHHZMiQISGnz83NlYcffjjeswEAALxS8jF58mR566235O2335bFixebth/PPPOM+RnK2LFjJT8/3//Iy8uL9ywBAAA3l3yMGTPGlH5cddVV5nn79u1l/fr1poRj6NChx02fkZFhHighOhMBALxa8rF//34pUybwbbX6pbi4ON4fhTDIIQAAT5V8XHDBBaaNR6NGjUxX22+++UaeffZZueGGG+L9UQAAIAXFPXy8+OKLZpCxW2+9VbZt2yb169eX4cOHywMPPCDJhzICAABSPnxUrVpVnnvuOfNIdnS1BQDAeZ65twsAAEgOhI+jKAUBAMAZhA+XsGi/AgBIEZ4JH2lppT0HAADAU+EjkX7YXCDrd+4r7dkAAMCbvV1SSTw62v6y75AMfH6e+f+6J369ky8AAAiPko8S2rjrQEnfAgAATyF8AAAAwkcyYOxTAAASg5IPl2CcEgBAqiB8AAAAR3kmfKQx0AcAAEnBM+EjFMtWV0EbDwAAnOHp8AEAAJxH+AAAAI4ifAAAAEcRPgAAgKMIHy5Bg1kAQKrwTPhIS9AJ2+K0DwBATDwTPkJhVFAAAJzn6fABAACcR/gAAACOInyEGO0UAAAQPgAAgEtQ8uESlNwAAFIF4QMAADjKM+EjLcRAH25t5UHzFQBAMvNM+AAAAMmB8AEAABxF+AiDBpwAACQG4aOEaF8BAEBsCB8u4dbGswAA9/F0+KBqBQAA53kmfKRJiL62NpQcAADgDM+EDwAAkBwIHwAAwFGEDwAA4CjCBwAAcBThwyUYbwQAkCo8HT44YQMA4JLwsXHjRrnmmmukZs2aUrFiRWnfvr0sXLgwER8FAABSTHq833DXrl3Su3dv6du3r0ybNk1q164tq1atkurVq0tpSos8zAcAAEjV8PHkk09KTk6OvP766/7XmjZtGnb6wsJC8/ApKCiI9ywBAAA3V7tMnTpVunXrJpdffrnUqVNHOnfuLK+++mrY6XNzcyUrK8v/0OCSSu0/GBkVAIBSDh9r1qyRCRMmSIsWLWTGjBkyYsQIueOOO+SNN94IOf3YsWMlPz/f/8jLy4v3LAEAADdXuxQXF5uSj8cff9w815KP5cuXy0svvSRDhw49bvqMjAzzAAAA3hD3ko/s7Gxp06ZNwGunnnqqbNiwQZKNRaUJAACpHz60p8uKFSsCXlu5cqU0btw43h8FAABSUNzDx+9//3tZsGCBqXZZvXq1vP322/LKK6/IyJEjpTTR0xYAAJeGj+7du8uUKVPknXfekXbt2smjjz4qzz33nAwZMkRSCb1YAABIkQan6vzzzzcPAACAYJ6+twsAAHAe4QMAADjK0+HDLXe1tdyyIAAAT/B0+LBjzA8AAJxB+AAAAI7yTvgIMdBHPGorqPIAACA23gkfHkIVEgAgmRE+AACAowgfAADAUZ4OH26pnqCnLQAglXg6fAAAAOcRPgAAgKM8Ez7SQvW1BQAAjvNM+AAAAMmB8HEUjTYBAHAG4QMAADjK0+HDLaUdLlkMAC5x4FCRzPpxm/kJhOLp8BEPnPgBINCT03+UYRO/Nj+BUAgfLi8VAQCnTfzvuoCfQDDCBwAAcJRnwkcaw3wAAJAUPBM+AABAcvB0+KBZBwAAzvN0+CB9AADgPG+HD5ew6JoDAEghhA8AAOAowgcAAHCUZ8IHPW0BAEgOngkfAAAgOXg6fFh0dwEAwHGeDh/xQEcTAABiQ/hwAQZLAwCkEsIHAABwFOEDAAA4ivABAAAc5ZnwkZYWeaQPGo4CAOAMz4QPLwUOty4XAMAdPB0+AACA8wgfLkBJBwAglSQ8fDzxxBOmvcWoUaMktVB3AQBAyoWPr7/+Wl5++WXp0KFDIj8GAACkkISFj71798qQIUPk1VdflerVqyfqYwAAQIpJWPgYOXKkDBo0SPr16xdxusLCQikoKAh4JEJawipWqJ4BACAW6ZIAkyZNksWLF5tqlxPJzc2Vhx9+WEqDRUtNAABSv+QjLy9P7rzzTnnrrbekQoUKJ5x+7Nixkp+f73/o3wMAAPeKe8nHokWLZNu2bdKlSxf/a0VFRTJ37lz5y1/+YqpZypYt6/9dRkaGeZQ2K4WrT1J53gEA3hP38HHOOefIsmXLAl4bNmyYtG7dWu65556A4AEAALwn7uGjatWq0q5du4DXKleuLDVr1jzudQAA4D2McAoAAFK/t0uw2bNnS2k7wU1tAQCAQzxd8kEzTQAAnOfp8AEAAJxH+AAAAI4ifLgAA7UCAFIJ4QMAADiK8FFClDoAABAbwsdRhAgAAJzhmfCRJscP9EHgAADAeZ4JHwAAIDkQPsKgVAQAgMQgfAAAAEd5OnwwvDoAAM7zdPgAAADO83b4oGEHAACO8074OL6nLQAAKAXeCR8AACApED5c2PjUTcsCAHAfwocL0HQFAJBKCB8lRCkDAACxIXwAAABHeTp8UGoBAIDzPB0+AACA8zwTPtIY5wMAgKTgmfABAACSA+HDBSxarwAAUgjhAwAAOIrwAQAAHOXp8GEfGdRimFAAABzh6fABAACc55nwEWtPWwYgAwAgMTwTPhLVS4TaGgAAYuPp8AEAAJxH+HABSl8AAKmE8AEAABzl6fBBiQEAAM7zdPgAAADOI3wAAABHeSZ8pKVFHumDcT0AAHCGZ8IHAABwafjIzc2V7t27S9WqVaVOnToyePBgWbFiRbw/BjaU2gAAPB0+5syZIyNHjpQFCxbIp59+KocPH5b+/fvLvn374v1RAAAgBaXH+w2nT58e8HzixImmBGTRokVy1llnSTKhqy0AAC4IH8Hy8/PNzxo1aoT8fWFhoXn4FBQUJHqWAACAWxucFhcXy6hRo6R3797Srl27sG1EsrKy/I+cnBxJJRbFJwAAJE/40LYfy5cvl0mTJoWdZuzYsaZ0xPfIy8tLyLxE7mgLAABSvtrltttuk48//ljmzp0rDRs2DDtdRkaGeQAAAG9IT0Q1xO233y5TpkyR2bNnS9OmTeP9EQixziM9BwDA1eFDq1refvtt+fDDD81YH1u2bDGva3uOihUrxvvjAACA19t8TJgwwbTd6NOnj2RnZ/sf//znPyXZ2MsHKCwAACCFq11SRaR5TaHFAAAgpXBvFwAA4CjCBwAAcJRnwkcaA30AAJAUPBM+3IzmKQCAVEL4AAAAjiJ8lBClDgAAxIbwAQAAHEX4AAAAjiJ8+FB/AgDi5YEn4RzPhI80oa8tAADJwDPhAwAAJAdPhw+3lAa6ZTkAAN7g6fABAEgsLo4QCuEDAAA4ivABAAAcRfgAAACOInwAABKG9vAIJc1KshFgCgoKJCsrS/Lz8yUzMzNu73vwcJG0Hjc9Lu/VoFpF2bj7QMTf929bV95b9LO0qltV8nbtl60FhdKkZiWpnJEuq7bulUNFxXJJlwaSVbGcTF2ySRpWryhdGlc3fz//p52Sf+CwHCm2zOgk2/YUmtd7NasprepV9X/O5t0H5b8/7TB/N3vF9uPmQ9+72LLMsutW1vcLpWyZNCkK87uTVbtqhmw/Ot/Rqlm5vDSuWcks++b8g9K+QZZZ9oKj66JKRrpZ76efUkOWbyyQvYVH/H/bKaeadG5UTT77cZvUqFzevPbLvkPmfU6tV1WW/pwv3ZtUl6/X7TK/O7tlbZm3arukly0jF3dqIKu375VvNuwSXQ0XdqwvNauUl027D8jnq3bI5d1yJC1NzP91++nn6Pqc9PUG6XlKTWlSq7J88M1G2bX/sHnvc1rXkZ93HZBy6WnSvUkN2bBzvyz9ebdc0LG++b3+7cT/rjP/v+b0RmZZluTtNsuu+0F6mTJH5/2A/29U/v7Dsin/gOzad1gKDh6WcmXLSKXyZeXHLXvMPO05eMT8nS7b3JXbzd/u2Fsoc1Zsl0u7NpQFa3aa91m3c58cPFzsf98yaWKWu2mtyuYz61StIBt+2S9O0u9Jr+Y15aOlm6VDwyz5YXOBnFK7slmmb3/ON9NkVkiXOpkVpPBIkRQXi1lf9u/DkSJLJi/Mk3Pb1TPbaue+Q3JakxrStkGmWR8/bd8nVSukm/dfuG6XXH1aI/n4281Sp2qGrNi6R3o3ryVfrN4hZ7WoZbbplG82SoeG1aRBtQryzld5Mqh9ttTJzJCdew/Jf37YKld0yzH7+L+WbZaruudIxfJlzXzsPXhEPly6SS7t0sCs5+825Zv39ikutuTNLzeY71z/NnWlQfWK5rucXa2C+b3OU93MDLPvRKKfs3xTgfk+2NXPqmi+L9v2HAx4Xedbt31X23GmTXamZFUqZ57rd0d/p/vimu37ZEDbujLju62STHz7qtLvue7v+h3S/eTDJZv80+n3KCO9jNnmvmOhHlfKly1j9gGlx4/CI8XmeK3HmPLpZaRWlQyz7+s6XbDmF7m0awPzvvqdrl65vFln+w8VmWl8xxylx4r/rt4p53esL+8v/tl89/RzDh0plre+3GC2s87DR99ukku6NDTzpr5c84vUqpohzWpXNs/1s3o0rSH1siqY84KeJ3TZdL7VwPb1zHLMW7XD7F+TF/7s3y/tdP/eubfQHK8O6LmvXlWZ+eM2uaZHY0kvmyZl09JkcOcG0q5BVqmdvz0TPnRHa/fgjLi9HwAAqeq0pjVk8vCepXb+9ky1i5YAOEmv/KOhpRk+I/s2k1vObhZxep3G90AgvTqJF/v61auOK7o19D+/pHMD/9WT0hKVcK7v1STgakzfV69qo6WlGPo3V3bLEbfzXd3F4tY+J/4+DOt9bBtEq1GNSiFfj/Q5keZD3y+a7+1ZLWsf936hHsPPPiWqz/a9PrRnY/9r5so689dSFt861Kt+RHZx5wZh1+/J7Cv9Tj12vNLSG/sxxVcSEq3g/SMSLdlVWtpTmtjjEkSL2aJxzenHDgpjBrSW0b9tGXF6ncb3WHR/P3nzdz1KPK9ucXGX4w8OJ0vXr/2EcOOZxw72fxjQKqA6ZEiPY9sw2G2/ae7/f/829cz7arHriU5yPkN7NTZ/c0X32MNH/axjJ5hU0L5h7EXAd5977PugReah3Nb32Daw02qdcLR420ero0LtF/bANLhTff98hNKtcXX/74O3uf3Ef+MZTQM+K9zjrt+28k/37i09Q372pJtP978+3HZR079tPdl94FDAOtQqz1Tz/y7vKAPb1ZP5Y3/jyOf9T49Gx70WaZvr61rdEe53gzpk+58PP6uZ9G52rGruvPbHfheN4P0jWIs6Vfz7ilY3qnDV8E4hfCRIPDbrpV0ayqOD24X9fc0qGXJGi2M7LJy5KtdStGiv0kNdUdrvMnSitja+exIdOFQksSpbNrXuZ6T10CUTel2WCfO+0X5apOk+ufMME24evujY99R3cB9+1ikxv3+6NmqIgn2yUH+jV7enn1IzZMmvXhjZ2/wobRuVarQd04Rrukp2VkV59bpuCf+8RH6bypRJS2jpvK6nr+/rZ9oRaZsPFe92frEifASxF32VNr3qPbftsSuwVLbsof6SympUOXZleLgo8Esb6Zzpa1imfHnFfjI84QHg6KT2A5Ne7UVDG64e+3/yB5GSZo9wqzLc+6ZF+4ERJmtep6opCdPGhD73ntvaXJXffk4Lf/F5D1ujUK1rD1XVotPqSSga2kjcJ9RiB79mP6/5Gpi6yW/b1JWfHj9PXry6s5zXvp5phKk/4ynq/aWEDWlVvHOI7i++pgCdc6rJ948MkOmjzpTSlDxn2iRxWdeG8voXv/ZEKG161WuVckc1DWPa2rrk71NOXri6s0xdslGqVSpvegKl6lW5ttHWXiaR3PXblqb3Q0Z6WbmoU32ZtmyLXHX0ith+gik6wVHGN6U9fOhVTJN7/3XCebYHDr3aKe1i1oX395Nuf/pPAsNHbMsX8eNsbxXrbOnJXa/K1bu39JKftu+Vro2OtQv6Q/9WpmeJ9tS44zfN5c5+LeXrdb9I8zpVZN2OfdHNe8D+GGL2g160Py15CVNy0hOsVofaq0Sj+Z5EK96rLc22Z+kFiVN9P7SHnz5KG+EjiHZfTBZmZy/lvkjx/D5oUbCvsVOqhQ/7gUfP4RXKHQsf2gU4mF71+jx3ZSf50+AjJoCZ94ql2uXoB5d0OyTDCUfbZKx7YpA5wfZ5ZnbEg/HJ0C6ssYi64KME6067g9aoHFjSod0oF4/7remB59t3fFUkeSfVxfn45Q7eX+wXMeGqodxoxZ/Olb/NWytPz1hR4vdK5HpLMyUfVgKDTvJJnjNtkkjGjeSlXkLJKvDAE7hO+rSqY0o3fndGU+nTqra8ccNpx528fMEj+L1O3Obj5LeDb9wJtf9w7G1G4sne9kXH0NDGkMFKWsoXbhWVdBdO1DEhVGjV0o9YhdqFgtelfR3YauNcT0seR/ZtLmseP08mDuvu+OdH2vfS0gKDdyKrXZIxb3poN3TWye48ATtkWnwLPl6/PrYvn9ZBJyp8/PDIuaY9xKnZmfL5PX0llQQf7LW49/mrOsu489vIxGGnme6xkeggVz46YJCPDnYVzNc47GRqTOwDCFW0ldSUxN+HnlzDvv85WuXko1f6c8f0jeuVZbh9Ndyqi7akxckDt4ZUrZ76NoY2UvZus+FLPsSTJR8+WtWpFwnLHx4gz17R0XSdj7V7cbyPhZY9EAaVfMRbSUsVE4HwESzMNoq9wZ5V8mR8EjtMpBOfvaogGpNu7pmw22HrVfn3j5wr/7r9DGlYvZKM6tfCjJehPXxOVuK+u1bAAbukn6OlIz72A6D9nKBjU2hDxB5Nfy2OPzU7sMue7/c+2SG61dr3nmq2BpElcc6p0XUhj0ajmpXMFamOm3Jmi1pyh62q6mSEC2jhDurRtzdNc7x6KtNWUhbO/43oaXp55Ni67uqor8rejTO44bMXw4e9tEm7uj91WUf5/uEBpgTON4ZOhXKRT4cn872PVJpnebQqzIc2HyegddTq/BfnmWGwfcM8F5ygEWZWxZL3m9fi0Vh2eB3qW4v8wzWyijU/aevoRNa62Fvsj+rX0jxUx5wseeDD72J+v4ReOaTF73MC2hBYoXunPHhB24C/0YCmrdOrVyof8HvfttbB6R6cGrjO7Ac0HWo8lFl/6CN9Q7S/iOTj28+Q81/8PKa/CXds1SvSZ6/sZP6vDe7ev7WXGSb9ipfnS06NipL3S/jbGERd8lHSapckPS90bXz88Osf3X6GuX1Dl6PDfvvUr1bRdAnW4bb1e6djl6zdsc8MP+9V2uhSS+B0HVzWraEZqv+uyUvl0+/DDSkf3+NLcXHgdzWhbT6ScB+m5CPKq5ynL+sotaqUl8cubidf39/PFN+F89SlHcxoliXdKaK94sq9pL0ZJOjegaEHu/GJthtfabf50Hu6+Gi1jIa9cANIOSW45COe32Vtna+DEelVmI5+Gm6gudb1MqVuiCL2cPuRfXPrPSLitX1P5n4Q0ezLGsq6NKpuuqJqg8zZf+gbnzYfYU4aiew6WVq0xETvzxJq2bRL8Ig+vw429taNPUxp4/ghXQK6//ru+5JoOgrnfeedKslAj4s6/oWuu8cvbm+CfKhDpd7TJVaRvl7F9rARdKHphTYflHxE2Eg6aqH9JKiDtPi+1CHaivnpaJRvf7khLg2SommEp4Ma6Y2tTnQwbV479sZsbetnmpuyOalzo+qmcZiOBKlXaLpcL8/5SXKn/RgwbLnv5mw+ia0zTdzn6NgEetWvy7lg7DkndVIM9Tfh3kf3lUlf55n/n2z3vn///izp/+e5McxfbO/vuzngV/edI9e/9rV8v7nAhNJlG8Pvi2G3S7jxP6KcFzeGFC0J8ZU0Kq2+0Rstaulp1wjdoeNFT/DavuWxT36QZKKlvXoRd0PvJrJw/S75cXOBvPDZatNLz94+Kx4sCV/yEW/JuA97puSjSvn0Em+waDagrxgz3KSh6ubDfn7UUwbOmxZd2xuhaX36F/f+xtyV8ZGLAovzw9ESHvXXa7pKadDGYafUruJfrgttQVCVCxq9U++Kar+4Dx7IqaQS9d31hUvfcp7sQSLtBKU14d61cc3KAdVfkdhLn1rWDT1sdLzpHXY/ufNMU/059bbepiomnHBjppR0eJPkO2zHnw6Sdn4HvZtzhhmuXBu9RlrXJeXbN31d75ON3j1ZhzjXgDbtzjPlz1d2Mm2s4noPHCv8IGPxloz7sGdKPrRoTRsUBQ8rHGkjxXIe+Gbcb00jyhMNu/3p6LMj3l33ZD/fTouuF/zxHDMkt76HNjbzndSu69nENOq8+71vza3Aw/Hdr0RvN62NAnftP2SuVLRrqL5V63HTxUk6hLKWRH1w9LbZI/o0l9krtpuGdXoVpeOzvLfo16t59c5Np8uofy6Rj5Yeu812OO0aZPrb84RiqllsGyMZux+HarAWTabQ9aY9j3Ta5vdNizitnvxPtvQjHgc/3Qaz7upj2rbobcpLXu0Sh5lyIf2uqXeH95JPlm2WRz7+Pu6f4Vv3T1/eQaZG8R0tzfOGlnorrZb59sH+csaTn8mOvaHbUAULtef5Gv9att+aASWT8LiSSJ4p+TiZgZZiaYFcLr2M6U3ia1eRFpd5KNnRUcOQzlPw1bQ2Ooul/YdOq1dEmvp97+nEvRQi9dbRYnkNcnploq/r1bt92HN9Hlw6Es6Tl3aIaT7ieYwo6Xv5SrjOalnruJsZhtvGwbugblf7iId3n9tK7jk3sP1Qx4ZZpqjeLpbSj3id6HU+Yw1/bm1wmmg6GNoNthvdhaM3t9S7sp5MGyAdh0MH4UsVeqyZObqPDGhbV16+NrZS4TEDfr0ZoHbJV9ow2H68iqVxtRv2YU+Fj2iOQYEDv0T2wNGdSEU6l9tvZx3LTmDafCQoDBfZm1oHiSZY6O2gT2ZApJLQO8TqcO/BtxP3ORLcqNKK7k6VbevH1oBST37J8mWePaaPaYukvWF02HX7HT4Dql1imGE9MWjDRF8XxKNvEHLahy9s63ids5bsRUv35ZMpqbL/RbJs69JyojveNq1dWf40uL1MONp4NRr2dWq/g3Aq0OHzX762mwyw3Xfr/0b0Mo1o2xwtJdHu48pemnFrn2Yy7+6+MuTo3XELDh4OugA4tlKqxfn+O4zzUcqiOQbpRtKqhmhua6xjLWidpTbgqxTUpqS7rc2BVhFEW5oS3AgpUQVxwTdH83npmq7mJk3RnEy0usNJeoJd8kB/GTswdCv54HuXZFc7cfuafYWx37cmntvEisOVmO+GUXr15CsyjxSIB7bLDjuomfLtooHjEIR+r6tOswWUCOJ5/tZxGvRqOXiQMt/Vt/3ArftyuO99tAf4ZDxwO0nb3Dxzecewv/etnYHts/1DE8RCSz+cPpbEm/YS0lvZv3ljD3nqsg7+u5Ffe/qvF57akFePmTomiy+IHw46Bh86cuziSe8D1S2OPY+SMUB7ps2HivYKSMdTWL9zv+npEYnuRHqztFCa1a5i6sT1qkGrLLRbm96M7EQNlgK6XwX9TrtjxkuoYb21i/C5Ud4xNXhebz7rFHll7hpJtEiNI4PDx619msu2gkJ5N8J9ZLRHjdKunUt/3i0fLdkk1/duUqIrwWRhD7rnd8iWD5dsks6NqpmGczpWhw7yFXlI9+NfC3XiCKah4KynZ4V+0zjtA4OPXlna6dgnGkwaVqsopz0+0zRCjkQHcDu1Xqb854etsm7n/pQ6cDtJu3frDTe1N4zuQydaP9pD6aZ/LJIRZzczx5NQ4w4FX4RpDxN9acLsnySVaXXwFbYSQ21j16lR9aiO3YdsJbc6GNp7I3qZmw/+/fM1MumrPDNWj5aujJ+V2uvIk9Uuvp1Ce0KE2xm0xEIbVupYBiUtKtY6cQ0eStsm3HzW8em+Vb3Aqgv7QFN6G3d7sd27t/SUePlN6zrmZ3Xb1Z/9XiDRsIez0223DC8teqvo4LYtT1/e0Zx4w92Kvmezmv6DRt9WdcyAVx0aBr6Pz2vXdzNXgNpDJF4S2cjMXvqmJ+tlD/WX927pZZ7r/h1uFE3ffWjs+0akUPr2jT0CnmuomTHqrICeXU6UHmjjWa2S0Z4KOg7Pv+44w7xuL8620xx7//lt5N+/P1vGDmwtvZv/ui8E83j2CBjrKJTgbas9lD4c2du/z/wj6F5H5m9CrFRtZ+SrkrBb/dhAU92airTdVaecaiFHl76rf0tTyv7H835tX1U7xFhGelzSEpVFenH0YH/zf53eVzofrWTch1Nzi56k+wadKme0qGVOOHoHzAVrfjGvb99zUMZ9+J1paHei+3LEk34Bm9epanpm1Mk8VnSuB00tktOTg733THDVTkno2CDaWLFjTjXpmTvTlBrEOsCQtpXQE092tYrSJMxVtIq2K2dJ9TilpjnQ6dggdloMqt0ItVGmDhQ0Z+V2s611/ns1qxX1+/+mdfyGFk8kvVfO6m17zb6sXaxXbt0jfVrWPmGY1m7Yc1fukEu7/lqqcNtvWsiXa38xRcU39A7f8LBX82Pr0BfwdLTI+WPP8V/1RjvoXiJu2qZVUXpSC+4h41sfWho5/OxmclX3RnLHpG/k4s4NzD6kJXk6XLkui9Nj3SQjXU/6XdKecnYnukbTkjYtDZmyeKN/rJ5wf/KH/q3ki9U7AkqitJGxtpV4dd4a11z1+6qR9fvpM+GaLmZk5zvD3GZAu0MrvYjVx/8uWC/jPlhuBilMxfSRZiVZ/56CggLJysqS/Px8ycyMXO2Rqs59bq78uGWPnNu2nrwURYvpHXsLTTGlb+CleNtz8LDsOXjkuN4Msfp+U4Gc98I883+96t2cf9A/mmJv2wmqNB0uKja3LdcxRE7Ed+LUIuHgOumZP2yV372x0Pz/ZOq5Bz4/T37YXBD1PpDstLHvhhDrVYOenky0pb+WTJQm7TbqGzTKd5O8SPeq2bBzv7koKDxSLH/+dKUJJRrWr3x5vgllWtqn9z/yGg22Wm178/8uND/njOkb1QWGHse6HR3ATLvvR+px1+/ZOeZztFrbPhbI9OWb5ZY3F8tNZzaV+wYda/DvRZZlyZod+6RJiLF6dD0tXLdL/vb5WvP8u4cHmJLgZDp/Jyx8jB8/Xp5++mnZsmWLdOzYUV588UU57bTji9+8GD627yk0O8dFnRtEdQOpVLJ7/yHTb19LGr5au9Ps8Ge2cK40KZ7W7dgnX/y0Qy7vmnNcWx392ry36GdpUz8z5t4yvn1g2vLNpjrEbftAsvtuU74JytqO4WSqVnftOyQffbtJLuhQ3wzc51UaPPR7YO+mfSL/+X6rqd6N5mJEG2CGaiNXeKQoZFsjHE/Dv7bN0yplJ5R6+PjnP/8p1113nbz00kvSo0cPee655+Tdd9+VFStWSJ06kVeCF8IHAABuE8v5OyHloM8++6zcdNNNMmzYMGnTpo0JIZUqVZLXXnstER8HAABSSNzDx6FDh2TRokXSr1+/Yx9Spox5Pn/+/OOmLywsNGnJ/gAAAO4V9/CxY8cOKSoqkrp1Axty6XNt/xEsNzfXFNP4Hjk50Q1aBAAAUlOpj/MxduxYUz/ke+TlHbs5GAAAcJ+4972pVauWlC1bVrZu3Rrwuj6vV+/4gYoyMjLMAwAAeEPcSz7Kly8vXbt2lZkzZ/pfKy4uNs979vRen3gAABAoIaOOjB49WoYOHSrdunUzY3toV9t9+/aZ3i8AAMDbEhI+rrzyStm+fbs88MADppFpp06dZPr06cc1QgUAAN7D8OoAACD1BxkDAAAIh/ABAAAcRfgAAACOInwAAIDU7+1SEr6b7HKPFwAAUofvvO07j6dU+NizZ4/5yT1eAABIPXoe114vKdXVVkdD3bRpk1StWlXS0tLinso01Oj9Y07UDSgVuXn53LxsiuVLbWy/1MW2ix+NExo86tevb+5mn1IlHzrDDRs2TOhn6MnLjScwLyyfm5dNsXypje2Xuth28XGiEg8fGpwCAABHET4AAICjPBU+MjIy5MEHHzQ/3cjNy+fmZVMsX2pj+6Uutl3pSLoGpwAAwN08VfIBAABKH+EDAAA4ivABAAAcRfgAAACOInwAAADCRyKMHz9emjRpIhUqVJAePXrIV199Veq72ty5c+WCCy4wQ9HqUPIffPBBwO+1I9IDDzwg2dnZUrFiRenXr5+sWrUqYJpffvlFhgwZYkbnq1atmvzud7+TvXv3Bkzz7bffyplnnmmWXYcof+qpp46bl3fffVdat25tpmnfvr188sknJV6+3Nxc6d69uxkqv06dOjJ48GBZsWJFwDQHDx6UkSNHSs2aNaVKlSpy6aWXytatWwOm2bBhgwwaNEgqVapk3mfMmDFy5MiRgGlmz54tXbp0Md3mmjdvLhMnTkzoPjBhwgTp0KGDf1TEnj17yrRp01J+ucJ54oknzD46atQoVyzjQw89ZJbH/tD93w3L5rNx40a55pprzDLo8UO/1wsXLnTF8UXXV/D204dus1TffkVFRTJu3Dhp2rSp2S7NmjWTRx99NOBmbam87ewL4XqTJk2yypcvb7322mvWd999Z910001WtWrVrK1bt5bqfH3yySfWfffdZ73//vu6V1lTpkwJ+P0TTzxhZWVlWR988IG1dOlS68ILL7SaNm1qHThwwD/Nueeea3Xs2NFasGCBNW/ePKt58+bW1Vdf7f99fn6+VbduXWvIkCHW8uXLrXfeeceqWLGi9fLLL/un+eKLL6yyZctaTz31lPX9999b999/v1WuXDlr2bJlJVq+AQMGWK+//rr53CVLlljnnXee1ahRI2vv3r3+aW655RYrJyfHmjlzprVw4ULr9NNPt3r16uX//ZEjR6x27dpZ/fr1s7755huzzmrVqmWNHTvWP82aNWusSpUqWaNHjzbz/+KLL5rlmT59esL2galTp1r/+te/rJUrV1orVqyw/vjHP5p1psuayssVyldffWU1adLE6tChg3XnnXf6X0/lZXzwwQettm3bWps3b/Y/tm/f7oplU7/88ovVuHFj6/rrr7e+/PJLMy8zZsywVq9e7Yrjy7Zt2wK23aeffmqOobNmzUr57ffYY49ZNWvWtD7++GNr7dq11rvvvmtVqVLFev75512x7Xw8ET5OO+00a+TIkf7nRUVFVv369a3c3FwrWQSHj+LiYqtevXrW008/7X9t9+7dVkZGhtlJlO4M+ndff/21f5pp06ZZaWlp1saNG83zv/71r1b16tWtwsJC/zT33HOP1apVK//zK664who0aFDA/PTo0cMaPnx4XJdRDxg6v3PmzPEvj+7I+uXy+eGHH8w08+fPN8/1oFCmTBlry5Yt/mkmTJhgZWZm+pfp7rvvNicSuyuvvNKEHyf3AV3Pf/vb31y1XHv27LFatGhhDu5nn322P3yk+jJq+NADcyipvmy+7/gZZ5wR9vduO77oftmsWTOzXKm+/QYNGmTdcMMNAa9dcsklJiS4adu5vs3HoUOHZNGiRaZYyn7zOn0+f/58SVZr166VLVu2BMy33rBHi/V8860/tTitW7du/ml0el2+L7/80j/NWWedJeXLl/dPM2DAAFP9sWvXLv809s/xTRPv9ZOfn29+1qhRw/zU7XL48OGAz9bivUaNGgUsoxb11a1bN2De9E6U3333XVTzn+h9QItJJ02aJPv27TPVL25ZLqVF11o0HTwfblhGLabWKs9TTjnFFE9rMbxblm3q1KnmuHD55ZebKoXOnTvLq6++6srji67HN998U2644QZT9ZLq269Xr14yc+ZMWblypXm+dOlS+fzzz2XgwIGu2nauDx87duwwJwf7Tqb0uW7AZOWbt0jzrT/1wGKXnp5uTu72aUK9h/0zwk0Tz/VTXFxs2gv07t1b2rVr5/9c3fH1SxJpGU92/vVAcuDAgYTtA8uWLTP1yVoffMstt8iUKVOkTZs2Kb9cPhqoFi9ebNruBEv1ZdQDtdbfT58+3bTf0QO61n3r7cBTfdnUmjVrzHK1aNFCZsyYISNGjJA77rhD3njjDdcdX7St3O7du+X666/3f14qb797771XrrrqKhOYypUrZ4KjHjs1ILtp26WX+B2AKK+gly9fbhK8W7Rq1UqWLFliSnTee+89GTp0qMyZM0fcIC8vT+6880759NNPTUMzt/FdRSptOKxhpHHjxjJ58mTTgC/VadjXq97HH3/cPNcTmH7/XnrpJbOfusnf//53sz21FMsNJk+eLG+99Za8/fbb0rZtW3OM0fChy+embef6ko9atWpJ2bJlj2vprM/r1asnyco3b5HmW39u27Yt4PfaWltbOdunCfUe9s8IN0281s9tt90mH3/8scyaNUsaNmwYsIxadKlXLZGW8WTnX1t564kkUfuAXl1pC/iuXbua0oGOHTvK888/n/LLpbQ4WfctbemvV0z60GD1wgsvmP/r1U+qL6OdXiW3bNlSVq9e7Yrtp70gtBTO7tRTT/VXLbnl+LJ+/Xr5z3/+IzfeeKP/tVTffmPGjPGXfmjV0LXXXiu///3v/SWQbtl2rg8feoLQk4PWodmvCvS51s8nK+1mpRvYPt9a3Kf1db751p/6BdMThc9nn31mlk+v5HzTaJderQP10atZvWqvXr26fxr75/imKen60Xa0Gjy0OkLnS5fJTreLFivaP1vrG/UAaV9Grd6wf5F03vQA4Du4nmj+ndoH9D0LCwtdsVznnHOOmT+96vI99Epai359/0/1ZbTTLog//fSTOWm7Yftp9WZwt3ZtQ6ClO245vqjXX3/dVC9ouySfVN9++/fvN20z7DTk6Hu7adt5oreLdofSlsATJ040rYBvvvlm0x3K3tK5NGhPAu3mpQ/dFM8++6z5//r16/3dqXQ+P/zwQ+vbb7+1LrroopDdqTp37my6033++eemZ4K9O5W2gtbuVNdee63pTqXrQruPBXenSk9Pt5555hnTKlx7AsSjO9WIESNMd7DZs2cHdIvbv3+/fxrtEqfdbz/77DPTJa5nz57mEdwlrn///qa7rnZzq127dsgucWPGjDHzP378+JBd4uK5D9x7772m1452hdNto8+1Jfm///3vlF6uSOy9XVJ9Ge+66y6zX+r20/1fu1xqV0vtkZXqy+brHq3fae22uWrVKuutt94y8/Lmm2/6p0n144v2LNFtpD00gqXy9hs6dKjVoEEDf1dbHYpB903tfeOWbac8ET6U9tHWnVH7ZGv3KO37XNq0T7qGjuCH7ny+LlXjxo0zO4ju4Oecc44ZU8Ju586dZofSfuDaTWzYsGEm1NhpP3DtdqfvoTu17rjBJk+ebLVs2dKsH+1epmNYlFSoZdOHjv3ho1+WW2+91XT50h3/4osvNgHFbt26ddbAgQNNH3T9EuqJ4/Dhw8ety06dOpn5P+WUUwI+IxH7gHaF03EU9L30oKXbxhc8Unm5YgkfqbyM2mUyOzvbvJ9+J/S5fQyMVF42n48++sicYPV737p1a+uVV14J+H2qH1903BI9ngTPc6pvv4KCAvM90/esUKGC+VwdD8reJTbVt51K039KXn4CAAAQHde3+QAAAMmF8AEAABxF+AAAAI4ifAAAAEcRPgAAgKMIHwAAwFGEDwAA4CjCBwAAcBThAwAAOIrwAQAAHEX4AAAA4qT/D/F3cTryoq3kAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -1899,8 +2133,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
-   "metadata": {},
+   "execution_count": 32,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:21.597705Z",
+     "iopub.status.busy": "2026-08-06T17:51:21.597601Z",
+     "iopub.status.idle": "2026-08-06T17:51:21.615250Z",
+     "shell.execute_reply": "2026-08-06T17:51:21.614687Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Add taxonomy information to retrieve species name similar to old data.\n",
@@ -1925,16 +2166,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
-   "metadata": {},
+   "execution_count": 33,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:21.617396Z",
+     "iopub.status.busy": "2026-08-06T17:51:21.617271Z",
+     "iopub.status.idle": "2026-08-06T17:51:21.622900Z",
+     "shell.execute_reply": "2026-08-06T17:51:21.622378Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([], dtype=int64)"
+       "array([ 383,   62,  257,  597, 2313,  134,  573,  202,  370,  161,  206,\n",
+       "        431, 1099,  472, 1069,  237,   68,  279, 1128, 4605,  209,  217,\n",
+       "        314,  374,  354,  372,  400,  733,  141,  145, 1066,  444,  932,\n",
+       "       4617,  185,  349, 4868,  103,   35, 1097, 1100,  172,   56, 1073,\n",
+       "         66,  838])"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1952,14 +2204,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
-   "metadata": {},
+   "execution_count": 34,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:21.625639Z",
+     "iopub.status.busy": "2026-08-06T17:51:21.625486Z",
+     "iopub.status.idle": "2026-08-06T17:51:21.657007Z",
+     "shell.execute_reply": "2026-08-06T17:51:21.656386Z"
+    }
+   },
    "outputs": [],
    "source": [
+    "# Trektellen sometimes exports several sighting submissions that fall in the\n",
+    "# same (species, date, start, end) window as separate rows instead of one\n",
+    "# merged row. Sum them so each window appears once per species -- otherwise\n",
+    "# duration_h summed per window is inflated by however many duplicate rows\n",
+    "# exist, while the count total (summed either way) is unaffected.\n",
+    "# Rows with no taxonomy match (species is NaN, e.g. incidental non-target\n",
+    "# species not in taxonomy.csv) are passed through unaggregated: they don't\n",
+    "# share a real species identity, so grouping them under the shared NaN key\n",
+    "# would wrongly sum together counts of different, unrelated species.\n",
+    "dnt_mapped = dnt[dnt[\"species\"].notna()]\n",
+    "dnt_unmapped = dnt[dnt[\"species\"].isna()]\n",
+    "\n",
+    "dnt_agg = pd.concat(\n",
+    "    [\n",
+    "        dnt_mapped.groupby([\"species\", \"date\", \"start\", \"end\"], as_index=False)[\n",
+    "            \"count\"\n",
+    "        ].sum(),\n",
+    "        dnt_unmapped[[\"species\", \"date\", \"start\", \"end\", \"count\"]],\n",
+    "    ],\n",
+    "    ignore_index=True,\n",
+    ")\n",
+    "\n",
     "don = pd.concat(\n",
     "    [\n",
     "        dot[[\"species\", \"date\", \"count\", \"start\", \"end\"]],\n",
-    "        dnt[[\"species\", \"date\", \"count\", \"start\", \"end\"]],\n",
+    "        dnt_agg[[\"species\", \"date\", \"count\", \"start\", \"end\"]],\n",
     "    ],\n",
     "    ignore_index=True,\n",
     ").sort_values(\"start\")"
@@ -1967,8 +2248,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
-   "metadata": {},
+   "execution_count": 35,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:21.658827Z",
+     "iopub.status.busy": "2026-08-06T17:51:21.658687Z",
+     "iopub.status.idle": "2026-08-06T17:51:22.233967Z",
+     "shell.execute_reply": "2026-08-06T17:51:22.233410Z"
+    }
+   },
    "outputs": [],
    "source": [
     "don.to_csv(\"../data/count/all_count_processed.csv\", index=False)"
@@ -1989,8 +2277,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
-   "metadata": {},
+   "execution_count": 36,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:22.236147Z",
+     "iopub.status.busy": "2026-08-06T17:51:22.236023Z",
+     "iopub.status.idle": "2026-08-06T17:51:22.245986Z",
+     "shell.execute_reply": "2026-08-06T17:51:22.245399Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2499,7 +2794,7 @@
        "180  Accipitridae (Hawks, Eagles, and Kites)  "
       ]
      },
-     "execution_count": 88,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2521,12 +2816,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
-   "metadata": {},
+   "execution_count": 37,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T17:51:22.247544Z",
+     "iopub.status.busy": "2026-08-06T17:51:22.247434Z",
+     "iopub.status.idle": "2026-08-06T17:51:22.489655Z",
+     "shell.execute_reply": "2026-08-06T17:51:22.489018Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtAAAAG1CAYAAADQhsPoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAADzxklEQVR4nOzdeVxOaf/A8c+ddLcqshQiKRGyxdgrpGTJMs/MY28YxtgZ+5owmQiDxzKGNBgzZtDjMY2smcjYs5VlkGUmY2w1orSc3x+9Oj+3FkWG8n2/Xuf16j7nOtdyLjN9u+7rXJdGURQFIYQQQgghRL7ovekKCCGEEEIIUZRIAC2EEEIIIUQBSAAthBBCCCFEAUgALYQQQgghRAFIAC2EEEIIIUQBSAAthBBCCCFEAUgALYQQQgghRAFIAC2EEEIIIUQB6L/pCghR3GRkZPDHH39gZmaGRqN509URQgghRD4oisLff/9NxYoV0dPLe4xZAmghCtkff/yBjY3Nm66GEEIIIV7CzZs3qVy5cp5pJIAWopCZmZkBmf8BlipVqlDzTk1NZdeuXbRv356SJUsWat7inyF9WPRJHxYP0o9FX2H3YWJiIjY2Nurv8bxIAC1EIcuatlGqVKnXEkAbGxtTqlQp+R9+ESV9WPRJHxYP0o9F3+vqw/xMv5SXCIUQQgghhCgACaCFEEIIIYQoAAmghRBCCCGEKAAJoIUQQgghhCgACaCFEEIIIYQoAAmghRBCCCGEKAAJoIUQQgghhCgACaCFEEIIIYQoAAmghRBCCCGEKAAJoIUQQgghhCgACaCFEEIIIYQoAAmghRBCCCGEKAAJoIUQQgghhCgA/TddASHyIy4ujmrVqnHq1Cnq16//0vm4ublRv359Fi9eXGh1y02dmeHoaY0LNU9tCYXAJlDHL5yUdE2h5i3+GdKHRZ/0YfEg/Vi0xc3r+EbLlxFoUah8fX3RaDRoNBr09fWpUqUKn376KQ8ePHjtZbu5uTF69Gidc19++SVarZZvv/0WgK1btzJ79mz1uq2t7T8STAshhBCi+JARaFHovLy8CA4OJi0tjZiYGAYMGMDDhw/ZtGnTP1qPmTNnMn/+fLZt24a3tzcAZcqU+UfrIIQQQojiR0agRaHTarVYWVlRuXJl2rdvz4cffsiuXbt00gQHB1OrVi0MDQ2pWbMmy5cv17l+9OhRGjRogKGhIS4uLpw6dSrf5SuKwogRI/jyyy/ZtWuXGjyD7ii1m5sb169fZ8yYMeqoeZaoqChat26NkZERNjY2jBw5kqSkpJd4GkIIIYQobiSAFq/V1atX2blzJyVLllTPrV69mqlTpzJ37lxiY2P5/PPPmT59OiEhIQAkJSXRqVMnHB0dOXHiBH5+fowbNy5f5aWlpdG3b19++OEHDhw4QMuWLXNNu3XrVipXroy/vz/x8fHEx8cDcPbsWTw9PenevTtnzpzh+++/5+DBgwwfPjzHfFJSUkhMTNQ5hBBCCFF8yRQOUeh27NiBqakp6enpJCcnA7Bw4UL1+uzZswkKCqJ79+4AVKtWjZiYGFatWkX//v3ZuHEj6enprF27FmNjY2rXrs2tW7f49NNPX1j26tWrATh9+jQ1a9bMM22ZMmUoUaIEZmZmWFlZqefnz59Pr1691JFqBwcHlixZgqurKytWrMDQ0FAnn4CAAGbNmvXiByOEEEKIYkFGoEWhc3d3Jzo6miNHjjBixAg8PT0ZMWIEAH/99Rc3b95k4MCBmJqaqsecOXO4cuUKALGxsdSrVw9j4/9fwaJZs2b5Krtly5aYmpoybdo00tLSXqr+J06cYN26dTr18/T0JCMjg2vXrmVLP3nyZBISEtTj5s2bL1WuEEIIIYoGGYEWhc7ExAR7e3sAlixZgru7O7NmzWL27NlkZGQAmSPF7733ns59JUqUADLnML+sunXrEhQURLt27fjggw/4/vvvdaaP5EdGRgaffPIJI0eOzHatSpUq2c5ptVq0Wu1L11kIIYQQRYsE0OK1mzlzJh06dODTTz+lYsWKVKpUiatXr9K7d+8c0zs5ObF+/XqePHmCkZERAL/++mu+y6tfvz779u2jXbt2/Otf/+KHH37INYg2MDAgPT1d51zDhg05f/68+keAEEIIIcSzZAqHeO3c3NyoXbs2n3/+OQB+fn4EBATw5ZdfcunSJc6ePUtwcLA6T7pXr17o6ekxcOBAYmJiCAsLY8GCBQUq09nZmf3793P48GHef/99nj59mmM6W1tbfvnlF37//Xfu3r0LwMSJEzl8+DDDhg0jOjqay5cvs337dnUaihBCCCHebTICLf4RY8eO5aOPPmLixIl8/PHHGBsbM3/+fCZMmICJiQl169ZVX9ozNTXlf//7H0OGDKFBgwY4OTnxxRdf0KNHjwKVWbt2bfbv30/btm3p0aMHW7ZsyZbG39+fTz75hOrVq5OSkoKiKDg7O3PgwAGmTp1Kq1atUBSF6tWr8+GHHxao/HOzPClVqlSB7nmR1NRUwsLCOOfnWeCpKeLtIH1Y9EkfFg/Sj+JVaJRXmXAqhMgmMTERc3NzEhISXlsA7e3tLf/DL6KkD4s+6cPiQfqx6CvsPizI72+ZwiGEEEIIIUQByBQOIfLB19eXhw8fEhoamu976swMR09r/OKEBaAtoRDYBOr4hZOSrnnxDeKtI31Y9EkfFg/Sj0VH3LyOb7oK2cgIdCG7ffs2I0aMwM7ODq1Wi42NDZ07d2bv3r1vumr/KDc3N3V7bD09PSpUqMC//vUvrl+//qarJoQQQgjxSiSALkRxcXE0atSIffv2ERgYyNmzZ9m5cyfu7u4MGzbsTVfvHzdo0CDi4+P5/fff+e9//8vNmzfp06fPm65WnlJTU990FYQQQgjxlpMAuhANHToUjUbD0aNHef/996lRowa1a9dm7NixOusY37hxAx8fH0xNTSlVqhQffPABf/75p3rdz8+P+vXrs3btWqpUqYKpqSmffvop6enpBAYGYmVlRfny5Zk7d65O+RqNhlWrVtGpUyeMjY2pVasWhw8f5rfffsPNzQ0TExOaNWum7viXZcWKFVSvXh0DAwMcHR1Zv359tny//vprunXrhrGxMQ4ODmzfvv2Fz8PY2BgrKyusra1p2rQpw4YN4+TJk+r1devWYWFhoXNPaGgoGs3/f5Vma2urjmQ/e2Q9p5yurVu3DoCdO3fSsmVLLCwssLS0pFOnTjptj4uLQ6PRsHnzZtzc3DA0NGTDhg2kp6czduxY9b4JEya80uYuQgghhCheJIAuJPfv32fnzp0MGzYMExOTbNezAkVFUejatSv379/nwIED7N69mytXrmRbIu3KlSv8/PPP7Ny5k02bNrF27Vo6duzIrVu3OHDgAF988QXTpk3LtsHI7Nmz6devH9HR0dSsWZNevXrxySefMHnyZI4fPw7A8OHD1fTbtm1j1KhRfPbZZ5w7d45PPvmEjz76iP379+vkO2vWLD744APOnDmDt7c3vXv35v79+wV6Pj/88EO23Qdf5NixY8THxxMfH8+tW7do2rQprVq1AmDcuHHqtfj4eBYsWICxsTEuLi4AJCUlMXbsWI4dO8bevXvR09OjW7du6m6IWSZOnMjIkSOJjY3F09OToKAg1q5dy5o1azh48CD3799n27ZtudYxJSWFxMREnUMIIYQQxZe8RFhIfvvtNxRFoWbNmnmm27NnD2fOnOHatWvY2NgAsH79emrXrs2xY8do3LgxkLmd9Nq1azEzM8PJyQl3d3cuXrxIWFgYenp6ODo68sUXXxAREUHTpk3V/D/66CM++OADIDMwbNasGdOnT8fT0xOAUaNG8dFHH6npFyxYgK+vL0OHDgVQR8sXLFiAu7u7ms7X15eePXsC8Pnnn7N06VKOHj2Kl5dXrm1dvnw5X3/9NYqi8PjxY2rUqEF4eHi+nylAuXLl1J9HjRpFfHw8x44dAzLXizY1NQUydyqcNm0aISEh1KlTByDbutFr1qyhfPnyxMTEqGkARo8eTffu3dXPixcvZvLkyer9K1euzLPeAQEBzJo1q0DtEkIIIUTRJSPQhSTrK/5npx/kJDY2FhsbGzV4hsytqy0sLIiNjVXP2draYmZmpn6uUKECTk5O6Onp6Zy7c+eOTv7Ozs461wHq1q2rcy45OVkdJY2NjaVFixY6ebRo0UKnLs/na2JigpmZWbayn9e7d2+io6M5ffo0Bw8exN7envbt2/P333/neV9OvvrqK9asWcN///tfnaAaMqfEdO3alXHjxql/PEDmKH6vXr2ws7OjVKlSVKtWTU3/rKwRa4CEhATi4+Np1qyZek5fX18nzfMmT55MQkKCety8ebPA7RNCCCFE0SEBdCFxcHBAo9FkCzyfpyhKjkH28+efXxBco9HkeO756QjPpsnKL6dzz973fH1yqmN+yn6eubk59vb22Nvb06JFC9asWcPly5f5/vvvAdDT08s2tzinl/giIiIYMWIE33zzDfXq1dO5lpSURJcuXWjWrBn+/v461zp37sy9e/dYvXo1R44c4ciRIwDZtvXOacpNQWi1WkqVKqVzCCGEEKL4kgC6kJQpUwZPT0/+85//kJSUlO36w4cPgczR5hs3buiMUsbExJCQkECtWrX+qeqqatWqxcGDB3XORUVFvZa6lChRAoAnT54AmdMz/v77b53nFR0drXPPb7/9Ro8ePZgyZYrONAvIDPT79OlDRkYG69ev1wn67927R2xsLNOmTaNt27bUqlWLBw8evLCO5ubmWFtb68wtT0tL48SJEwVurxBCCCGKJ5kDXYiWL19O8+bNadKkCf7+/jg7O5OWlsbu3btZsWIFsbGxtGvXDmdnZ3r37s3ixYtJS0tj6NChuLq65jlN4HUZP348H3zwAQ0bNqRt27b873//Y+vWrezZs+eV8378+DG3b98G4M8//2TOnDkYGhrSvn17AN577z2MjY2ZMmUKI0aM4OjRo+oKGpAZaHfu3Jn69eszePBgNS8AKysr/Pz82LNnD7t27eLRo0c8evQIyAyCS5cujaWlJV999RXW1tbcuHGDSZMm5aveo0aNYt68eTg4OFCrVi0WLlyo/gEkhBBCCCEBdCGqVq0aJ0+eZO7cuXz22WfEx8dTrlw5GjVqxIoVK4DMqQ+hoaGMGDGC1q1bo6enh5eXF0uXLn0jde7atStffvkl8+fPZ+TIkVSrVo3g4GDc3NxeOe/Vq1ezevVqAEqXLo2zszNhYWE4OjoCmaP2GzZsYPz48Xz11Ve0a9cOPz8/Bg8eDGQG3RcuXODChQtUrFhRJ29FUThw4ACPHj2iefPmOteCg4Px9fXlu+++Y+TIkdSpUwdHR0eWLFmSr3Zl9Z2vry96enoMGDCAbt26kZCQUKD2n5vlWejTOVJTUwkLC+Ocn2e2aTWiaJA+LPqkD4sH6UfxKjSKLHArRKFKTEzE3NychISE1xZAe3t7y//wiyjpw6JP+rB4kH4s+gq7Dwvy+1tGoMUri4uLo1q1apw6dYr69esXSp4ajYZt27bRtWvXQskPMjduGT169D82HaPOzHD0tMaFmqe2hEJgE6jjF05Ket4rvoi3k/Rh0Sd9WDxIP75+cfM6vukqvDbyEqHIk6+vr84uf5aWlnh5eXHmzJk3XTUdOe1qGBsbS+XKlenevTspKSl8+OGHXLp0Sb2eteOjEEIIIURBSAAtXsjLy0vd7W/v3r3o6+vTqVOnN12tPB07doxWrVrh6enJDz/8gFarxcjIiPLly7/pqgkhhBCiiJMAWryQVqvFysoKKysr6tevz8SJE7l58yZ//fVXjunT09MZOHAg1apVw8jICEdHR7788sts6dauXUvt2rXRarVYW1vrbDH+PH9/fypUqJBtmbuc7Nu3jzZt2vDRRx+xZs0adfm8Z0ep161bx6xZszh9+rQ6up61AkhCQgKDBw+mfPnylCpVijZt2nD69OkXliuEEEKId4PMgRYF8ujRIzZu3Ii9vT2WlpY5psnIyKBy5cps3ryZsmXLEhUVxeDBg7G2tlZ3ClyxYgVjx45l3rx5dOjQgYSEBA4dOpQtL0VRGD16NKGhoRw8eBAHB4c867dt2zZ69erFzJkz81y27sMPP+TcuXPs3LlTXbLP3NwcRVHo2LEjZcqUISwsDHNzc1atWkXbtm25dOkSZcqUyZZXSkoKKSkp6uesXR6FEEIIUTxJAC1eaMeOHZiamgKZO/9ZW1uzY8cOnW3Fn1WyZElmzZqlfq5WrRpRUVFs3rxZDaDnzJnDZ599xqhRo9R0jRs31sknLS2Nfv36cfz4cQ4dOkTlypXzrOejR4/417/+xZQpU1645rORkRGmpqbo6+tjZWWlnt+3bx9nz57lzp07aLVaABYsWEBoaCg//vijusTeswICAnTaK4QQQojiTaZwiBdyd3cnOjqa6Ohojhw5Qvv27enQoQPXr1/P9Z6VK1fi4uJCuXLlMDU1ZfXq1dy4cQOAO3fu8Mcff9C2bds8yx0zZgyHDx8mMjLyhcEzZAbFHh4erF69+oVbqufmxIkTPHr0CEtLS0xNTdXj2rVrXLlyJcd7Jk+eTEJCgno8u8ukEEIIIYofGYEWL2RiYoK9vb36uVGjRpibm7N69WrmzJmTLf3mzZsZM2YMQUFBNGvWDDMzM+bPn8+RI0eAzEA3Pzw8PNi0aRPh4eH07t37helLlChBaGgoPXr0wN3dnX379uHk5JTPVmbKyMjA2tqaiIiIbNeeX+Uji1arVUerhRBCCFH8SQAtCkyj0aCnp8eTJ09yvB4ZGUnz5s0ZOnSoeu7Z0VszMzNsbW3Zu3cv7u7uuZbTpUsXOnfuTK9evShRogT//ve/X1g3rVbL1q1bef/993F3d2fv3r3UqVMnx7QGBgakp6frnGvYsCG3b99GX18fW1vbF5YnhBBCiHePTOEQL5SSksLt27e5ffs2sbGxjBgxgkePHtG5c+cc09vb23P8+HHCw8O5dOkS06dP59ixYzpp/Pz8CAoKYsmSJVy+fJmTJ0/muJ15t27dWL9+PR999BE//vhjvuprYGDAli1baN68OW3atOHs2bM5prO1teXatWtER0dz9+5dUlJSaNeuHc2aNaNr166Eh4cTFxdHVFQU06ZN4/jx4/kqXwghhBDFm4xAixfauXMn1tbWQObocc2aNfnhhx9wc3PLMf2QIUOIjo7mww8/RKPR0LNnT4YOHcrPP/+spunfvz/JycksWrSIcePGUbZsWd5///0c83v//ffJyMigb9++6Onp0b179xfWuWTJkmzevJmePXvSpk0b9u7dmy1Njx492Lp1K+7u7jx8+JDg4GB8fX0JCwtj6tSpDBgwgL/++gsrKytat25NhQoV8vG0/t+5WZ6vbSvvc36esvVsESV9WPRJHxYP0o/iVWgURVHedCWEKE4SExMxNzcnISHhtQXQ3t7e8j/8Ikr6sOiTPiwepB+LvsLuw4L8/pYpHEIIIYQQQhSATOF4Tdzc3Khfvz6LFy9+01Up8jQaDdu2baNr167/SHkRERG4u7vz4MGDXFfeyI86M8PR0xoXXsUAbQmFwCZQxy+clHRNoeYt/hnSh0Wf9GHxIP34+sTN6/imq/DaFekRaF9fX3Ub5mcPLy+vN101tm7dyuzZs197Ofv378fd3Z0yZcpgbGyMg4MD/fv3Jy0t7bWXLYQQQgjxLiryI9BeXl4EBwfrnHuVNXkVRSE9PR19/Vd7NDlt+VzYzp8/T4cOHRg5ciRLly7FyMiIy5cv8+OPP5KRkfFay3769CkGBgY659LT09Ul7oQQQgghiqsiH+lotVqsrKx0jtKlSwMQFxeHRqMhOjpaTf/w4UM0Go26UUZERAQajYbw8HBcXFzQarVERkZy5coVfHx8qFChAqampjRu3Jg9e/bolL18+XIcHBwwNDSkQoUKOqtIuLm5MXr0aPXzhg0bcHFxwczMDCsrK3r16sWdO3fU61n12Lt3Ly4uLhgbG9O8eXMuXryYa9t3796NtbU1gYGB1KlTh+rVq+Pl5cXXX3+tBrfr1q3DwsKC0NBQatSogaGhIR4eHjq75eWnrba2tsyZMwdfX1/Mzc0ZNGiQmveOHTtwcnJCq9Vy/fp1Hjx4QL9+/ShdujTGxsZ06NCBy5cvA5l/oJQrV44tW7aoedevX5/y5curnw8fPkzJkiV59OiReu7u3bt069ZNHWXfvn27ei09PZ2BAwdSrVo1jIyMcHR05Msvv1Svnz17Fj09Pe7evQvAgwcP0NPT41//+peaJiAggGbNmuX4nJ88eULHjh1p2rQp9+/fz7U/hBBCCPFuKPIBdGGZMGECAQEBxMbG4uzszKNHj/D29mbPnj2cOnUKT09POnfurG5Hffz4cUaOHIm/vz8XL15k586dtG7dOtf8nz59yuzZszl9+jShoaFcu3YNX1/fbOmmTp1KUFAQx48fR19fnwEDBuSap5WVFfHx8fzyyy95tu3x48fMnTuXkJAQDh06RGJios6mJC9qa5b58+dTp04dTpw4wfTp09W8AwIC+Prrrzl//jzly5fH19eX48ePs337dg4fPoyiKHh7e5OamopGo6F169bqHzAPHjwgJiaG1NRUYmJigMw/Jho1aoSpqala9qxZs/jggw84c+YM3t7e9O7dWw1mMzIyqFy5Mps3byYmJoYZM2YwZcoUNm/eDECdOnWwtLTkwIEDAPzyyy9YWlrqPLeIiAhcXV2zPbuEhATat2/P06dP2bt3b47fLKSkpJCYmKhzCCGEEKL4KvIB9I4dOzA1NdU5Xmbusb+/Px4eHlSvXh1LS0vq1avHJ598Qt26dXFwcGDOnDnY2dmpI583btzAxMSETp06UbVqVRo0aMDIkSNzzX/AgAF06NABOzs7mjZtypIlS/j55591RlkB5s6di6urK05OTkyaNImoqCiSk5NzzPNf//oXPXv2xNXVFWtra7p168ayZcuyBXCpqaksW7aMZs2a0ahRI0JCQoiKiuLo0aMAL2xrljZt2jBu3Djs7e3Vrb1TU1NZvnw5zZs3x9HRkT/++IPt27fz9ddf06pVK+rVq8fGjRv5/fffCQ0NBTJH57MC6F9++YV69erRpk0bnW8Fnl9j2tfXl549e2Jvb8/nn39OUlKSWv+SJUsya9YsGjduTLVq1ejduze+vr5qAP180B4REUH//v3JyMggJiaGtLQ0oqKispX5559/4urqSvny5fnpp58wMTHJsR8CAgIwNzdXDxsbmxzTCSGEEKJ4KPIBtLu7O9HR0TrHsGHDCpyPi4uLzuekpCQmTJiAk5MTFhYWmJqacuHCBXVU1sPDg6pVq2JnZ0ffvn3ZuHEjjx8/zjX/U6dO4ePjQ9WqVTEzM1ODtedHeZ2dndWfszYveXaqx7NKlChBcHAwt27dIjAwkIoVKzJ37lxq165NfHy8mk5fX1+nfTVr1sTCwoLY2Nh8tTW3ZwSZu/49W+fY2Fj09fV577331HOWlpY4Ojqq5bm5uXH+/Hnu3r3LgQMHcHNzw83NjQMHDqjB7POjwc+WYWJigpmZmc5zWblyJS4uLpQrVw5TU1NWr16tU/9ng/YDBw7g7u5O69atOXDgAMeOHePJkye0aNFCp8x27dphZ2fH5s2bs833ftbkyZNJSEhQj2enxwghhBCi+CnyAbSJiYk6Ipp1ZH3NnvUy27N7xaSmpuaaz7PGjx/Pli1bmDt3LpGRkURHR1O3bl2ePn0KZO7Id/LkSTZt2oS1tTUzZsygXr16PHz4MFveSUlJtG/fHlNTUzZs2MCxY8fYtm0bgJpflmcXAtdoMpfVedELgZUqVaJv37785z//ISYmhuTkZFauXKmTJiuvnM69qK25PSMAIyMjnbxz25dHURQ13bNTKrICaFdXV51gtmXLljr3P79AukajUZ/L5s2bGTNmDAMGDGDXrl1ER0fz0Ucf6dQ/K2j/7bffOHfuHK1atVLLzJoyYmZmplNGx44diYyMVKeW5Ear1VKqVCmdQwghhBDFV5FfhSMv5cqVAyA+Pp4GDRoA6LxQmJfIyEh8fX3p1q0bkDlPOC4uTieNvr4+7dq1o127dsycORMLCwv27duXbavpCxcucPfuXebNm6d+vX/8+PFXaFnuSpcujbW1NUlJSeq5tLQ0jh8/TpMmTQC4ePEiDx8+pGbNmvlua345OTmRlpbGkSNHaN68OQD37t3j0qVL1KpVC/j/KRX//e9/1WDWzMyM1NRUVq5cScOGDbMFs3mJjIykefPmDB06VD135coVnTRZQfucOXOoV68epUqVwtXVlYCAAB48eJDj/Od58+ZhampK27ZtiYiIwMnJ6WUeiRBCCCGKmSI/Ap2SksLt27d1jqzVFoyMjGjatCnz5s0jJiaGX375hWnTpuUrX3t7e7Zu3Up0dDSnT5+mV69eOiPBO3bsYMmSJURHR3P9+nW++eYbMjIycHR0zJZXlSpVMDAwYOnSpVy9epXt27cXyhrRq1at4tNPP2XXrl1cuXKF8+fPM3HiRM6fP0/nzp3VdCVLlmTEiBEcOXKEkydP8tFHH9G0aVM1oH5RWwvCwcEBHx8fBg0axMGDBzl9+jR9+vShUqVK+Pj4qOnc3Nz49ttvcXZ2plSpUmpQvXHjxmxzkV/E3t6e48ePEx4ezqVLl5g+fTrHjh3TSZOV/4YNG9T8nZ2d1ZcDcytzwYIF9O7dmzZt2nDhwoUC1UsIIYQQxVORH4HeuXOnOlc4i6OjoxrsrF27lgEDBuDi4oKjoyOBgYG0b9/+hfkuWrSIAQMG0Lx5c8qWLcvEiRN1Xs6zsLBg69at+Pn5kZycjIODA5s2baJ27drZ8ipXrhzr1q1jypQpLFmyhIYNG7JgwQK6dOnySm1v0qQJBw8eZMiQIfzxxx+YmppSu3ZtQkNDdUZUjY2NmThxIr169eLWrVu0bNmStWvX5rutBRUcHMyoUaPo1KkTT58+pXXr1oSFhelMw3B3dyc9PV0ncHV1dc1W9/wYMmQI0dHRfPjhh2g0Gnr27MnQoUP5+eefddK5u7uzdetWtUyNRkOrVq3YsWNHtikjz1q0aBHp6enqi441atTIV73OzfIs9OkcqamphIWFcc7PM9u0FlE0SB8WfdKHxYP0o3gVGiW3SauiWFi3bh2jR4/OcW62eD0SExMxNzcnISHhtQXQ3t7e8j/8Ikr6sOiTPiwepB+LvsLuw4L8/i7yI9DizYmLi6NatWqcOnWK+vXrv+nqvJCbmxv169dn8eLF/0h5dWaGo6c1LtQ8tSUUAptAHb9wUtKzvxgq3n7Sh0Wf9GHx8C73Y9y8jm+6CkVekZ8DvXLlSszMzEhLS1PPPXr0iJIlS9KqVSudtJGRkWg0Gi5duvRKZWbtGvgmR3X9/PzQaDR4eXlluxYYGIhGoynwXOJ/iq2tbY5BrJ+f32sNxLdu3Vooc8+FEEII8W4r8gG0u7s7jx490lnVIjIyEisrK44dO6azNnNERAQVK1bM9xzW101RFJ3Av6Csra3Zv38/t27d0jkfHBxMlSpVgMwNSF420M9tyb+3WU51zjpXpkyZAq3u8bz09PSXfrlSCCGEEMVHkQ+gHR0dqVixorpJBmQGyj4+PlSvXp2oqCid8+7u7kDm+ssTJkygUqVKmJiY8N577+nkcf36dTp37kzp0qUxMTGhdu3ahIWFERcXp+ZRunRpNBqNuiW3oigEBgZiZ2eHkZER9erV48cff9QpX6PREB4ejouLC1qtlsjISNzc3Bg5ciQTJkygTJkyWFlZ4efn98K2ly9fnvbt2xMSEqKei4qK4u7du3TsqPv1zLFjx/Dw8KBs2bKYm5vj6urKyZMnddJoNBpWrlyJj48PJiYmzJkzhwcPHtC7d2/KlSuHkZERDg4OBAcH69x39epV3N3dMTY2pl69ehw+fPiFdc+Pl61z1kj22rVrsbOzQ6vVoigKbm5ujB49Wr33Rf8G1q1bh4WFBTt27MDJyQmtVsv169cLpW1CCCGEKLqKfAANmXNb9+/fr37ev3+/ujlH1vmnT59y+PBhNfj96KOPOHToEN999x1nzpzhX//6F15eXly+fBmAYcOGkZKSwi+//MLZs2f54osvMDU1xcbGhi1btgCZ6ynHx8fz5ZdfAjBt2jSCg4NZsWIF58+fZ8yYMfTp04cDBw7o1HfChAkEBAQQGxur7rAXEhKCiYkJR44cITAwEH9/f3bv3v3Ctg8YMIB169apn9euXUvv3r2z7Zz3999/079/fyIjI/n1119xcHDA29ubv//+WyfdzJkz8fHx4ezZswwYMIDp06cTExPDzz//TGxsLCtWrKBs2bI690ydOpVx48YRHR1NjRo16Nmz5yuNrL9qnQF+++03Nm/ezJYtW3Jd+/tF/wYAHj9+TEBAAF9//TXnz5+nfPny2fJJSUkhMTFR5xBCCCFE8VUsXiJ0c3NjzJgxpKWl8eTJE06dOkXr1q1JT09nyZIlAPz66688efIEd3d3rly5wqZNm7h16xYVK1YEYNy4cezcuZPg4GA+//xzbty4QY8ePahbty4AdnZ2anlZOx2WL18eCwsLIHO3wYULF7Jv3z6aNWum3nPw4EFWrVqlszSbv78/Hh4eOm1wdnZm5syZQOZaysuWLWPv3r3Z0j2vU6dODBkyhF9++YVGjRqxefNmDh48qLNMHUCbNm10Pq9atYrSpUtz4MABOnXqpJ7v1auXGoRC5lbjDRo0ULfxtrW1zVaHcePGqSPes2bNonbt2vz222/qRi05mThxYrY1uZ8+faqzWcnL1jkrr/Xr16ub6TwvP/8GIHP6x/Lly6lXr16ubQkICGDWrFm5XhdCCCFE8VIsAmh3d3eSkpI4duwYDx48oEaNGpQvXx5XV1f69u1LUlISERERVKlSBTs7O3744QcURck2FzolJQVLS0sARo4cqW5S0q5dO3r06KGOFuckawvt5wPep0+fqrsgZskKRp/1fN7W1tbcuXPnhW0vWbIkffr0ITg4mKtXr1KjRo0c63nnzh1mzJjBvn37+PPPP0lPT+fx48fcuHEjz7p9+umn9OjRg5MnT9K+fXu6du2q7jCYU92z1uS+c+dOngH0+PHj1akvWZYsWcIvv/zyynUGqFq1aq7BM8DJkydf+G8AwMDAIM9+B5g8eTJjx45VPycmJqo7TgohhBCi+CkWAbS9vT2VK1dm//79OtsyW1lZUa1aNQ4dOsT+/fvVEc2MjAxKlCjBiRMnKFGihE5epqamAHz88cd4enry008/sWvXLgICAggKCmLEiBE51iHr5bKffvqJSpUq6VzTarU6n01MTLLd//z6hRqNJt8vrA0YMID33nuPc+fOZRuJzeLr68tff/3F4sWLqVq1KlqtlmbNmvH06dM869ahQweuX7/OTz/9xJ49e2jbti3Dhg1jwYIFOdZdo8lcCuhFdS9btiz29vY657JG9l+1zrmde1Z+/g1A5m6WWW3KjVarzdbHQgghhCi+ikUADZmj0BERETx48IDx48er511dXQkPD+fXX3/lo48+AqBBgwakp6dz586dbEvdPcvGxoYhQ4YwZMgQJk+ezOrVqxkxYoQ6vzg9PV1Nm/WS2Y0bNwq8k96rql27NrVr1+bMmTP06tUrxzSRkZEsX74cb29vAG7evKluef4i5cqVw9fXF19fX1q1asX48eN1AujX5VXq/CL5/TcghBBCCPG8YhVADxs2jNTUVJ0A1tXVlU8//ZTk5GT1BcIaNWrQu3dv+vXrR1BQEA0aNODu3bvs27ePunXr4u3tzejRo+nQoQM1atTgwYMH7Nu3j1q1agGZ0wM0Gg07duzA29sbIyMjzMzMGDduHGPGjCEjI4OWLVuSmJhIVFQUpqam9O/f/7W2f9++faSmpqpzsp9nb2/P+vXrcXFxITExkfHjx2NkZPTCfGfMmEGjRo2oXbs2KSkp7NixQ30Or9vL1jk/8vNvQAghhBAiJ8ViFQ7IDKCfPHmCvb09FSpUUM+7urry999/U716dZ15qcHBwfTr14/PPvsMR0dHunTpwpEjR9Q06enpDBs2jFq1auHl5YWjoyPLly8HoFKlSsyaNYtJkyZRoUIFhg8fDsDs2bOZMWMGAQEB1KpVC09PT/73v/9RrVq1195+ExOTXINnyFyd48GDBzRo0IC+ffsycuTIHFeUeJ6BgQGTJ0/G2dmZ1q1bU6JECb777rtCrHnuXrbO+fWifwNCCCGEEDnRKIqivOlKCFGcJCYmYm5uTkJCAqVKlSrUvFNTUwkLC8Pb2zvbvHlRNEgfFn3Sh8WD9GPRV9h9WJDf38VmBFoIIYQQQoh/QrGZAy3eLnFxcVSrVo1Tp05Rv379N12dV5a1JXpoaGi+76kzMxw9rXGh1kNbQiGwCdTxCyclPe/VQcTbSfqw6JM+LB7exX6Mm9fxxYlEvrzREWhfX180Gk22w8vL601W662g0WhyDNZ8fX3p2rXrP14fIYQQQgiR6Y2PQHt5eREcHKxz7lXW1FUUhfT0dPT133jTRBGUmpoqc+GEEEIIkac3Pgdaq9ViZWWlc5QuXRrInAag0WiIjo5W0z98+BCNRkNERAQAERERaDQawsPDcXFxQavVEhkZSUpKirpqg6GhIS1btuTYsWNqPln3/fTTT9SrVw9DQ0Pee+89zp49q1O/qKgoWrdujZGRETY2NowcOZKkpCT1+oYNG3BxccHMzAwrKyt69eqls4NgVjl79+7FxcUFY2NjmjdvzsWLFwvl+eW3nS8q/3//+x+NGjXC0NAQOzs7Zs2aRVpaGpC5UcuzW2cDpKWlYWVllW3L8OdduHCB5s2bY2hoSO3atdV+A1i3bl22lUNCQ0N1Ni6xtbXN8VsKAD8/vxyvrVu3DoCdO3fSsmVLLCwssLS0pFOnTly5ckXNO+vf1+bNm3Fzc8PQ0JANGzaQnp7O2LFj1fsmTJiAvGsrhBBCiCxvPIAuLBMmTCAgIIDY2FicnZ2ZMGECW7ZsISQkhJMnT2Jvb4+npyf379/XuS9rU5Bjx45Rvnx5unTpQmpqKgBnz57F09OT7t27c+bMGb7//nsOHjyoLlsHmVt1z549m9OnTxMaGsq1a9eybVENMHXqVIKCgjh+/Dj6+vq57hj4Mu3OTzvzKj88PJw+ffowcuRIYmJiWLVqFevWrWPu3LlA5q6MO3fuJD4+Xr0nLCyMR48e8cEHH+RZv/Hjx/PZZ59x6tQpmjdvTpcuXbh3716+23fs2DHi4+OJj4/n1q1bNG3aVN34ZNy4ceq1+Ph4FixYgLGxsbq1d1JSEmPHjuXYsWPs3bsXPT09unXrlm2XxIkTJzJy5EhiY2Px9PQkKCiItWvXsmbNGg4ePMj9+/fZtm1brnVMSUkhMTFR5xBCCCFE8fXGA+gdO3Zgamqqc8yePbvA+fj7++Ph4UH16tUxNDRkxYoVzJ8/nw4dOuDk5MTq1asxMjJizZo1OvfNnDkTDw8P6tatS0hICH/++acaLM2fP59evXoxevRoHBwcaN68OUuWLOGbb74hOTkZyByd7dChA3Z2djRt2pQlS5bw888/8+jRI51y5s6di6urK05OTkyaNImoqCg1j9z07Nkz27PZuHGjej0pKSnf7cyr/Llz5zJp0iT69++PnZ0dHh4ezJ49m1WrVgHQvHlzHB0dWb9+vZpfcHAw//rXv3S2vc7J8OHD6dGjB7Vq1WLFihWYm5tnq1teypUrp34zERgYSHx8PFu2bAEyt9zOuhYXF8e0adMIDg6mTp06APTo0YPu3bvj4OBA/fr1WbNmDWfPniUmJkanjNGjR9O9e3eqVatGxYoVWbx4MZMnT1brvXLlSszNzXOtY0BAAObm5uoh60gLIYQQxdsbD6Dd3d2Jjo7WOYYNG1bgfLJGHQGuXLlCamoqLVq0UM+VLFmSJk2aEBsbq3Nfs2bN1J/LlCmDo6OjmubEiROsW7dOJ4D19PQkIyODa9euAXDq1Cl8fHyoWrUqZmZmuLm5AXDjxg2dcpydndWfra2tAXSmeuRk0aJF2Z5Nly5dXqqdeZV/4sQJ/P39ddo5aNAg4uPjefz4MZA5Cp01V/3OnTv89NNP6ij2kCFDdO7N7fnq6+vj4uKSrW758dVXX7FmzRr++9//Uq5cOZ1rN27coGvXrowbN05nRPzKlSv06tULOzs7SpUqpW5o83zfPPtvJyEhgfj4+BzrnZvJkyeTkJCgHjdv3ixw+4QQQghRdLzxN+1MTEywt7fP8ZqeXmZ8/+z806zpFTnlkyUr/bNzabPOP38uJ1lpMjIy+OSTTxg5cmS2NFWqVCEpKYn27dvTvn17NmzYQLly5bhx4waenp48ffpUJ/2zL6Y9m39erKyssj0bMzMzHj58WOB25lV+RkYGs2bNonv37tnqYGhoCEC/fv2YNGkShw8f5vDhw9ja2qpTKfz9/Rk3blyebXlWVvl6enrZ5hbn1L8RERGMGDGCTZs2Ua9ePZ1rSUlJdOnShWbNmuHv769zrXPnztjY2LB69WoqVqxIRkYGderUydY3z/7beRlarfaVXnwVQgghRNHyxkeg85I10vjs3NtnXyjMjb29PQYGBhw8eFA9l5qayvHjx6lVq5ZO2l9//VX9+cGDB1y6dImaNWsC0LBhQ86fP4+9vX22w8DAgAsXLnD37l3mzZtHq1atqFmz5gtHlQtTQdqZl4YNG3Lx4sUc25n1R4ylpSVdu3YlODiY4OBgPvroI/X+8uXL69zzrGefb1paGidOnFCfb7ly5fj77791Xsp8vn9/++03evTowZQpU7IF+Iqi0KdPHzIyMli/fr3OHw337t0jNjaWadOm0bZtW2rVqsWDBw9e+CzMzc2xtrbOsd5CCCGEEPAWjECnpKRw+/ZtnXP6+vqULVsWIyMjmjZtyrx587C1teXu3btMmzbthXmamJjw6aefMn78eMqUKUOVKlUIDAzk8ePHDBw4UCetv78/lpaWVKhQgalTp1K2bFl1neWJEyfStGlThg0bxqBBgzAxMSE2Npbdu3ezdOlSqlSpgoGBAUuXLmXIkCGcO3fupeZvv6yCtDMvM2bMoFOnTtjY2PCvf/0LPT09zpw5w9mzZ5kzZ46a7uOPP6ZTp06kp6fTv3//fOX9n//8BwcHB2rVqsWiRYt48OCBOvXjvffew9jYmClTpjBixAiOHj2qrqAB8OTJEzp37kz9+vUZPHiwzr8TKysr/Pz82LNnD7t27eLRo0fqvHNzc3NKly6NpaUlX331FdbW1ty4cYNJkyblq86jRo1i3rx5ar0XLlyojvoLIYQQQqC8Qf3791eAbIejo6OaJiYmRmnatKliZGSk1K9fX9m1a5cCKPv371cURVH279+vAMqDBw908n7y5IkyYsQIpWzZsopWq1VatGihHD16VL2edd///vc/pXbt2oqBgYHSuHFjJTo6Wiefo0ePKh4eHoqpqaliYmKiODs7K3PnzlWvf/vtt4qtra2i1WqVZs2aKdu3b1cA5dSpU7nW79SpUwqgXLt2LddnAyjbtm3L8Zn5+PgUuJ0vKn/nzp1K8+bNFSMjI6VUqVJKkyZNlK+++kqn7IyMDKVq1aqKt7d3rvXOcu3aNQVQvv32W+W9995TDAwMlFq1ail79+7VSbdt2zbF3t5eMTQ0VDp16qR89dVXStY/y6w8cjoURVFcXV1zvBYcHKwoiqLs3r1bqVWrlqLVahVnZ2clIiJC57lm5Z/VV1lSU1OVUaNGKaVKlVIsLCyUsWPHKv369dN57nlJSEhQACUhISFf6Qvi6dOnSmhoqPL06dNCz1v8M6QPiz7pw+JB+rHoK+w+LMjvb42ivJsL3EZERODu7s6DBw+yrUUscvb48WMqVqzI2rVrc5wvLTIlJiZibm5OQkICpUqVKtS8U1NTCQsLw9vbWzZ8KaKkD4s+6cPiQfqx6CvsPizI7+83PoVDvP0yMjK4ffs2QUFBmJub66wEIoQQQgjxrpEAWmTj5uZG/fr1Wbx4MZC57Fu1atWoXLky69ateye3Sff19eXhw4eEhobm+546M8PR0xoXaj20JRQCm0Adv3BS0l+8oox4+0gfFn3Sh8XDu9iPcfM6vukqFBtv9Socr5ObmxuKoryx6Ru+vr45bkPt5eX1RurzrK1bt+q8DGlra4uiKNy8eZO2bdsWWjkajUYnIE1NTeXf//431tbWnDlz5pXyzmkbeCGEEEKIwvDuDSW+Rby8vNTNSbK8ynrCiqKQnp7+yiPEZcqUeaX7X8bjx4/p0aMHly5d4uDBg1SvXv0fKffp06cYGBj8I2UJIYQQonh4Z0eg3wZarVbdijrrKF26NJDzCOrDhw/RaDREREQAmS9CajQawsPDcXFxQavVEhkZyZUrV/Dx8aFChQqYmprSuHFj9uzZo1P28uXLcXBwwNDQkAoVKvD++++r19zc3Bg9erT6ecOGDbi4uGBmZoaVlRW9evXSWe86qx579+7FxcUFY2NjmjdvzsWLF/P1HB4+fEj79u35/fffdYJnRVEIDAzEzs4OIyMj6tWrx48//qje9+DBA3r37k25cuUwMjLCwcFB/YMka9fBBg0aoNFo1B0ifX196dq1KwEBAVSsWJEaNWoA8Pvvv/Phhx+qy9/5+PgQFxeXr/oLIYQQ4t0iAXQxMGHCBAICAoiNjcXZ2ZlHjx7h7e3Nnj17OHXqFJ6ennTu3Fndwvr48eOMHDkSf39/Ll68yM6dO2ndunWu+T99+pTZs2dz+vRpQkNDuXbtGr6+vtnSTZ06laCgII4fP46+vr663nNebt++jaurKxkZGRw4cEDdZhxg2rRpBAcHs2LFCs6fP8+YMWPo06cPBw4cAGD69OnExMTw888/Exsby4oVKyhbtiwAR48eBWDPnj3Ex8ezdetWNd+9e/eq63nv2LGDx48f4+7ujqmpKb/88gsHDx7E1NQULy+vbLsW5iQlJYXExESdQwghhBDFl0zheIN27NiBqampzrmJEycyffr0AuXj7++Ph4eH+tnS0lJny+s5c+awbds2tm/fzvDhw7lx4wYmJiZ06tQJMzMzqlatSoMGDXLN/9lA2M7OjiVLltCkSRMePXqkU/+5c+fi6uoKwKRJk+jYsSPJycnqduA5GTVqFHZ2dhw+fBhj4/9/4S4pKYmFCxeyb98+mjVrppZ98OBBVq1ahaurKzdu3KBBgwa4uLgAmXO1s2TtYmlpaYmVlZVOmSYmJnz99dfq1I21a9eip6fH119/re5mGBwcjIWFBREREbRv3z7X+gMEBAQwa9asPNMIIYQQoviQEeg3yN3dnejoaJ1j2LBhBc4nK4DMkpSUxIQJE3BycsLCwgJTU1MuXLigjkB7eHhQtWpV7Ozs6Nu3Lxs3buTx48e55n/q1Cl8fHyoWrUqZmZm6nSIrPyyODs7qz9njSS/aGvzzp07c+nSJVatWqVzPiYmhuTkZDw8PDA1NVWPb775hitXrgDw6aef8t1331G/fn0mTJhAVFRUnmVlqVu3rs685xMnTvDbb79hZmamllOmTBmSk5PVsvIyefJkEhIS1OPmzZv5qocQQgghiiYZgX6DTExMsLe3z/Ganl7m3zbP7nOTmpqaaz7PGj9+POHh4SxYsAB7e3uMjIx4//331ekIZmZmnDx5koiICHbt2sWMGTPw8/Pj2LFj2VYlSUpKon379rRv354NGzZQrlw5bty4gaenZ7bpDc8uYp41kpuRkZHnM+jTpw9dunRhwIABpKenM27cOJ37fvrpJypVqqRzT9aLlh06dOD69ev89NNP7Nmzh7Zt2zJs2DAWLFiQZ5nPP6+MjAwaNWrExo0bs6XNGsnOi1arfaWXP4UQQghRtEgA/ZbKCtzi4+PV6RX5XZItMjISX19funXrBsCjR4+yvRCnr69Pu3btaNeuHTNnzsTCwoJ9+/Zl22HwwoUL3L17l3nz5mFjYwNkzqEuTP369aNEiRL079+fjIwMdfRcq9Vy48YNdVpITsqVK4evry++vr60atWK8ePHs2DBAnWEOT09/YXlN2zYkO+//57y5csX+s6BQgghhCh+JIB+g1JSUrh9+7bOOX19fcqWLYuRkRFNmzZl3rx52NracvfuXaZNm5avfO3t7dm6dSudO3dGo9Ewffp0nZHgHTt2cPXqVVq3bk3p0qUJCwsjIyMDR0fHbHlVqVIFAwMDli5dypAhQzh37pzOGtGFpXfv3ujp6dG3b18yMjKYNGkS48aNY8yYMWRkZNCyZUsSExOJiorC1NSU/v37M2PGDBo1akTt2rVJSUlhx44d1KpVC4Dy5ctjZGTEzp07qVy5MoaGhpibm+da9vz58/Hx8cHf35/KlStz48YNtm7dyvjx46lcuXKht1cIIYQQRZcE0G/Qzp07dVadAHB0dOTChQtA5sttAwYMwMXFBUdHRwIDA1/4QhvAokWLGDBgAM2bN6ds2bJMnDhRZ2UICwsLtm7dip+fH8nJyTg4OLBp0yZq166dLa9y5cqxbt06pkyZwpIlS2jYsCELFix4Ldt59+zZkxIlStC7d28yMjKYPXs25cuXJyAggKtXr2JhYUHDhg2ZMmUKAAYGBkyePJm4uDiMjIxo1aoV3333HZD5h8iSJUvw9/dnxowZtGrVSl3+73nGxsb88ssvTJw4ke7du/P3339TqVIl2rZt+0oj0udmeRb6iHZqaiphYWGc8/PUmTIjig7pw6JP+rB4kH4Ur0KjPDvJVgjxyhITEzE3NychIeG1BdDe3t7yP/wiSvqw6JM+LB6kH4u+wu7Dgvz+lhFoIV6TOjPD0dMavzhhAWhLKAQ2gTp+4aSkawo1b/HPkD4s+qQPi4fX3Y9x8zoWep7i7SHL2Ik34ubNmwwcOJCKFStiYGBA1apVGTVqFPfu3XvTVRNCCCGEyJME0OIfd/XqVVxcXLh06RKbNm3it99+Y+XKlezdu5dmzZpx//7911JufnYVFEIIIYR4EQmgxT9u2LBhGBgYsGvXLlxdXalSpQodOnRgz549/P7770ydOhWA5cuX4+DggKGhIRUqVOD9999X83Bzc2P48OEMHz4cCwsLLC0tmTZtms662ba2tsyZMwdfX1/Mzc0ZNGgQAFFRUbRu3RojIyNsbGwYOXIkSUlJQOaujnXr1s1W50aNGjFjxozX+ViEEEIIUURIAC3+Uffv3yc8PJyhQ4diZGSkc83KyorevXvz/fffc+zYMUaOHIm/vz8XL15k586dtG7dWid9SEgI+vr6HDlyhCVLlrBo0SK+/vprnTTz58+nTp06nDhxgunTp3P27Fk8PT3p3r07Z86c4fvvv+fgwYMMHz4cyNy2PCYmhmPHjql5nDlzhlOnTuHr65tjm1JSUkhMTNQ5hBBCCFF8yUuE4h91+fJlFEVR12t+Xq1atXjw4AHXrl3DxMSETp06YWZmRtWqVdUNZbLY2NiwaNEiNBoNjo6OnD17lkWLFqkjzQBt2rRRdzeEzE1bevXqxejRowFwcHBgyZIluLq6smLFCipXroynpyfBwcE0btwYgODgYFxdXbGzs8uxzgEBAcyaNetVHosQQgghihAZgRZvlawpGM2aNaNq1arY2dnRt29fNm7cyOPHj3XSNm3aVN0yPOuey5cv6+w+6OLionPPiRMnWLduHaampurh6elJRkYG165dA2DQoEFs2rSJ5ORkUlNT2bhxIwMGDMi1zpMnTyYhIUE9bt68+crPQQghhBBvLxmBFv8oe3t7NBoNMTExdO3aNdv1CxcuULp0aSpXrszJkyeJiIhg165dzJgxAz8/P44dO4aFhUW+yzMxMdH5nJGRwSeffMLIkSOzpa1SpQoAnTt3RqvVsm3bNrRaLSkpKfTo0SPXMrRaLVqtNt91EkIIIUTRJgG0+EdZWlri4eHB8uXLGTNmjM486Nu3b7Nx40b69euHRqNBX1+fdu3a0a5dO2bOnImFhQX79u2je/fuAPz66686ef/66684ODhQokSJXMtv2LAh58+fx97ePtc0+vr69O/fn+DgYLRaLf/+978xNi7c9ZyFEEIIUXRJAC3+ccuWLaN58+Z4enoyZ84cqlWrxvnz5xk/fjyVKlVi7ty57Nixg6tXr9K6dWtKly5NWFgYGRkZODo6qvncvHmTsWPH8sknn3Dy5EmWLl1KUFBQnmVPnDiRpk2bMmzYMAYNGoSJiQmxsbHs3r2bpUuXquk+/vhjdZ72oUOHXs+DEEIIIUSRJAG0+Mc5ODhw/Phx/Pz8+PDDD7l37x5WVlZ07dqVmTNnUqZMGSwsLNi6dSt+fn4kJyfj4ODApk2bqF27tppPv379ePLkCU2aNKFEiRKMGDGCwYMH51m2s7MzBw4cYOrUqbRq1QpFUahevToffvhhtjo2b96ce/fu8d57771UO8/N8nxtW3mf8/OUrWeLKOnDok/6sHiQfhSvQgJo8UZUrVqV4ODgXK+3bNmSiIiIPPMoWbIkixcvZsWKFTlej4uLy/F848aN2bVrV555K4rCn3/+ySeffJJnOiGEEEK8eySAFuI5d+7cYf369fz+++989NFHb7o6QgghhHjLSAAtcuXm5kb9+vVZvHjxm65KvkRERODu7s6DBw9yXalj3bp1jB49mocPH+aaT4UKFShbtixfffUVpUuXfun61JkZjp62cF8+1JZQCGwCdfzCSUnXvPgG8daRPiz6pA+Ljrh5Hd90FUQxJQH0G+br60tISEi2856enuzcufMN1Oj/bd269R+ZF6bRaNi2bVu2Ze18fX15+PAhoaGh2e550fSOV/HsduBCCCGEEM+TAPot4OXllW0+8KusK6woCunp6ejrv1r3lilT5pXuF0IIIYQojmQnwreAVqvFyspK58iaOhAXF4dGoyE6OlpN//DhQzQajToKGxERgUajITw8HBcXF7RaLZGRkVy5cgUfHx8qVKiAqakpjRs3Zs+ePTplL1++HAcHBwwNDalQoQLvv/++es3NzU3d8hpgw4YNuLi4YGZmhpWVFb169eLOnTvq9ax67N27FxcXF4yNjWnevDkXL14slOeUkpLCyJEjKV++PIaGhrRs2ZJjx45lS3fo0CHq1auHoaEh7733HmfPns2WJjQ0lBo1amBoaIiHh4e6e2BcXBx6enocP35cJ/3SpUupWrWqjE4LIYQQQgLo4mTChAkEBAQQGxuLs7Mzjx49wtvbmz179nDq1Ck8PT3p3LkzN27cAOD48eOMHDkSf39/Ll68yM6dO2ndunWu+T99+pTZs2dz+vRpQkNDuXbtGr6+vtnSTZ06laCgII4fP46+vn6e22AXtH1btmwhJCSEkydPYm9vj6enJ/fv39dJN378eBYsWMCxY8coX748Xbp0ITU1Vb3++PFj5s6dS0hICIcOHSIxMZF///vfANja2tKuXbts3wgEBwfj6+urs3V4lpSUFBITE3UOIYQQQhRfEkC/BXbs2IGpqanOMXv27ALn4+/vj4eHB9WrV8fS0pJ69erxySefULduXRwcHJgzZw52dnZs374dgBs3bmBiYkKnTp2oWrUqDRo0yHGL6ywDBgygQ4cO2NnZ0bRpU5YsWcLPP//Mo0ePdNLNnTsXV1dXnJycmDRpElFRUSQnJ+dZ9549e2Z7Bhs3blSvJyUlsWLFCubPn0+HDh1wcnJi9erVGBkZsWbNGp28Zs6ciYeHB3Xr1iUkJIQ///yTbdu2qddTU1NZtmwZzZo1o1GjRoSEhBAVFcXRo0eBzE1UNm3aREpKCgCnT58mOjo61xU5AgICMDc3Vw8bG5s82yqEEEKIok0C6LeAu7s70dHROsewYcMKnI+Li4vO56SkJCZMmICTkxMWFhaYmppy4cIFdQTaw8ODqlWrYmdnR9++fdm4cSOPHz/ONf9Tp07h4+ND1apVMTMzw83NDUDNL4uzs7P6s7W1NYDOVI+cLFq0KNsz6NKli3r9ypUrpKam0qJFC/VcyZIladKkCbGxsTp5NWvWTP25TJkyODo66qTR19fXeVY1a9bEwsJCTdO1a1f09fXVoHvt2rW4u7tja2ubY90nT55MQkKCemRNBxFCCCFE8SQvEb4FTExMsLe3z/Ganl7m3zjPzr19djrC8/k8a/z48YSHh7NgwQLs7e0xMjLi/fff5+nTpwCYmZlx8uRJIiIi2LVrFzNmzMDPz49jx45lWwYuKSmJ9u3b0759ezZs2EC5cuW4ceMGnp6ean5Znl25I2vKQ0ZGRp7PwMrKKtszMDMzU5eby2r/81MoFEXJcVrF855Pk9M9WecMDAzo27cvwcHBdO/enW+//TbPpfy0Wu0rvfQphBBCiKJFRqDfcuXKlQMgPj5ePffsC4V5iYyMxNfXl27dulG3bl2srKyy7c6nr69Pu3btCAwM5MyZM8TFxbFv375seV24cIG7d+8yb948WrVqRc2aNV84qlyY7O3tMTAw4ODBg+q51NRUjh8/Tq1atXTS/vrrr+rPDx484NKlS9SsWVM9l5aWpvOS4MWLF3n48KFOmo8//pg9e/awfPlyUlNT6d69++tolhBCCCGKIBmBfgukpKRw+/ZtnXP6+vqULVsWIyMjmjZtyrx587C1teXu3btMmzYtX/na29uzdetWOnfujEajYfr06TojwTt27ODq1au0bt2a0qVLExYWRkZGBo6OjtnyqlKlCgYGBixdupQhQ4Zw7ty5l5qn/bJMTEz49NNPGT9+PGXKlKFKlSoEBgby+PFjBg4cqJPW398fS0tLKlSowNSpUylbtqzOGtMlS5ZkxIgRLFmyhJIlSzJ8+HCaNm1KkyZN1DS1atWiadOmTJw4kQEDBmBkZPRPNVUIIYQQbzkJoN8CO3fuVOcKZ3F0dOTChQtA5hzcAQMG4OLigqOjI4GBgbRv3/6F+S5atIgBAwbQvHlzypYty8SJE3VWiLCwsGDr1q34+fmRnJyMg4MDmzZtonbt2tnyKleuHOvWrWPKlCksWbKEhg0bsmDBAp15yq/bvHnzyMjIoG/fvvz999+4uLgQHh6ebbfAefPmMWrUKC5fvky9evXYvn07BgYG6nVjY2MmTpxIr169uHXrFi1btmTt2rXZyhs4cCBRUVEvvYrIuVmelCpV6qXuzU1qaiphYWGc8/P8Rza5EYVP+rDokz4UQmgUWdhWiBzNnTuX7777Lsd1pPOSmJiIubk5CQkJry2A9vb2ll/cRZT0YdEnfVg8SD8WfYXdhwX5/S0j0OKd4ufnR2hoqDqPPKftwh89ekRsbCxLly59pWkqdWaGo6c1fsUa69KWUAhsAnX8wklJf/HLk+LtI31Y9Ekfvt3i5nV801UQ7wB5iVC8NbI2KhkyZEi2a0OHDkWj0eS4ccur+PLLL1m3bp3OueHDh9OyZUtcXV0LbRMYIYQQQhQfEkCLt4qNjQ3fffcdT548Uc8lJyezadMmqlSp8tL5KopCWlpatvPm5ubZluxbt24dKSkpfP/995QoUeKlyxRCCCFE8SQBtHirNGzYkCpVqrB161b13NatW7GxsaFBgwbqOUVRCAwMxM7ODiMjI+rVq8ePP/6oXo+IiECj0RAeHo6LiwtarZbIyMhs5fn6+uqs0OHm5sbIkSOZMGECZcqUwcrKCj8/v9fSViGEEEIUTRJAi7fORx99RHBwsPo5axWSZ02bNo3g4GBWrFjB+fPnGTNmDH369OHAgQM66SZMmEBAQACxsbE6OyTmJSQkBBMTE44cOUJgYCD+/v7s3r071/QpKSkkJibqHEIIIYQoviSAFm+dvn37cvDgQeLi4rh+/TqHDh2iT58+6vWkpCQWLlzI2rVr8fT0xM7ODl9fX/r06cOqVat08vL398fDw4Pq1atjaWmZr/KdnZ2ZOXMmDg4O9OvXDxcXF/bu3Ztr+oCAAMzNzdXDxsbm5RouhBBCiCJBVuEQb52yZcvSsWNHQkJCUBSFjh07UrZsWfV6TEwMycnJeHh46Nz39OlTnWkeAC4uLgUu//mRamtr6zx3XZw8eTJjx45VPycmJkoQLYQQQhRjEkCLt9KAAQMYPnw4AP/5z390rmXtpvjTTz9RqVIlnWtarVbns4mJSYHLfn4tSY1Go7OD4/O0Wm22coUQQghRfEkALd5KXl5ePH36FABPT0+da05OTmi1Wm7cuIGrq+ubqJ4QQggh3mESQIu3UokSJYiNjVV/fpaZmRnjxo1jzJgxZGRk0LJlSxITE4mKisLU1JT+/fu/iSoLIYQQ4h0hAbR4a+W1jebs2bMpX748AQEBXL16FQsLCxo2bMiUKVP+wRrm7dwsz9e2lfc5P0/ZeraIkj4s+qQPhRAaRVGUN10JIYqTxMREzM3NSUhIeG0BtLe3t/ziLqKkD4s+6cPiQfqx6CvsPizI729Zxk4IIYQQQogCkCkc4p3h5+dHaGgo0dHR/0h5dWaGo6c1LtQ8tSUUAptAHb9wUtI1hZq3+GdIHxZ90odvp7h5Hd90FcQ7REag30HPb1+dJWv764cPHxbL8seNG5fnhihCCCGEEPkhAbQoVrKWvnuWoiikpaVhamqa790Ic5OamvpK9wshhBCi6JMAWuQpKiqK1q1bY2RkhI2NDSNHjiQpKUm9bmtry+eff86AAQMwMzOjSpUqfPXVV4VS9r179+jZsyeVK1fG2NiYunXrsmnTJp00bm5uDB8+nLFjx1K2bFk8PDzUkezw8HBcXFzQarVERkbi5+dH/fr1de4PDg6mVq1aGBoaUrNmTZYvX65ei4uLQ6PRsHnzZtzc3DA0NGTDhg2F0jYhhBBCFF0SQItcnT17Fk9PT7p3786ZM2f4/vvvOXjwoLpDYJagoCBcXFw4deoUQ4cO5dNPP+XChQuvXH5ycjKNGjVix44dnDt3jsGDB9O3b1+OHDmiky4kJAR9fX0OHTrEqlWr1PMTJkwgICCA2NjYbNtzA6xevZqpU6cyd+5cYmNj+fzzz5k+fTohISE66SZOnMjIkSOJjY3NtqkLQEpKComJiTqHEEIIIYoveYnwHbVjxw5MTU11zqWnp+t8nj9/Pr169WL06NEAODg4sGTJElxdXVmxYgWGhoYAeHt7M3ToUCAz2Fy0aBERERHUrFnzlcqvVKkS48aNUz+PGDGCnTt38sMPP/Dee++p5+3t7QkMDFQ/3759GwB/f388PDxyrcPs2bMJCgqie/fuAFSrVo2YmBhWrVqlsxnL6NGj1TQ5CQgIYNasWbleF0IIIUTxIgH0O8rd3Z0VK1bonDty5Ah9+vRRP584cYLffvuNjRs3qucURSEjI4Nr165Rq1YtAJ3RXY1Gg5WVFXfu3Hnl8tPT05k3bx7ff/89v//+OykpKaSkpGBiYqJzn4uLS45l5HYe4K+//uLmzZsMHDiQQYMGqefT0tIwNzfPdz4AkydPZuzYsernxMREbGxs8rxHCCGEEEWXBNDvKBMTE+zt7XXO3bp1S+dzRkYGn3zyCSNHjsx2f5UqVdSfn1+8XKPRkJGR8crlBwUFsWjRIhYvXkzdunUxMTFh9OjR2V4UfD6gftF5QK3f6tWrdUazIfvW4XnlA6DVatFqtXmmEUIIIUTxIQG0yFXDhg05f/58tkD3nxIZGYmPj486Kp2RkcHly5fVke9XUaFCBSpVqsTVq1fp3bv3K+cnhBBCiHeHBNAiVxMnTqRp06YMGzaMQYMGYWJiQmxsLLt372bp0qWvvXx7e3u2bNlCVFQUpUuXZuHChdy+fbtQAmjI3Fhl5MiRlCpVig4dOpCSksLx48d58OCBzpQMIYQQQohnSQAtcuXs7MyBAweYOnUqrVq1QlEUqlevzocffviPlD99+nSuXbuGp6cnxsbGDB48mK5du5KQkFAo+X/88ccYGxszf/58JkyYgImJCXXr1lVfmnxV52Z5UqpUqULJK0tqaiphYWGc8/PMNnVGFA3Sh0Wf9KEQQqMoivKmKyFEcZKYmIi5uTkJCQmvLYD29vaWX9xFlPRh0Sd9WDxIPxZ9hd2HBfn9LSPQ4p0RFxdHtWrVOHXqVLYNVV6HOjPD0dMaF2qe2hIKgU2gjl84KemaQs1b/DOkD4u+d7EP4+Z1fNNVEOKtIhupFAJfX180Gg1DhgzJdm3o0KFoNBp8fX0LtcycdtX7J/n6+uLn5/dS92btFPjw4cNs12xtbVm8ePEr1S03NjY2xMfHU6dOndeSvxBCCCHeDRJAFxIbGxu+++47njx5op5LTk5m06ZNOku+idcrPT09xyX0nj59SokSJbCyskJf/+W/eHl+CT0hhBBCvHskgC4kDRs2pEqVKmzdulU9t3XrVmxsbGjQoIFO2pSUFEaOHEn58uUxNDSkZcuWHDt2TL2eNUK7d+9eXFxcMDY2pnnz5ly8eBGAdevWMWvWLE6fPo1Go0Gj0bBu3ToAFi5cqK6ZbGNjw9ChQ3n06JFO+atXr8bGxgZjY2O6devGwoULsbCwUK/7+vrStWtXnXtGjx6Nm5tbru1fvnw5Dg4OGBoaUqFCBd5///0CPL3cvag969atw8LCgh07duDk5IRWq+X69evY2toyZ84cfH19MTc3Z9CgQcTFxaHRaIiOjlbvj4mJwdvbG1NTUypUqEDfvn25e/euet3NzY3hw4czduxYypYtm+fOhkIIIYR4N0gAXYg++ugjgoOD1c9r165lwIAB2dJNmDCBLVu2EBISwsmTJ7G3t8fT05P79+/rpJs6dSpBQUEcP34cfX19Na8PP/yQzz77jNq1axMfH098fLy6Moaenh5Llizh3LlzhISEsG/fPiZMmKDmeejQIYYMGcKoUaOIjo7Gw8ODuXPnvlK7jx8/zsiRI/H39+fixYvs3LmT1q1bv1KeWV7UHoDHjx8TEBDA119/zfnz5ylfvjyQuRV5nTp1OHHiBNOnT8+Wd3x8PK6urtSvX5/jx4+zc+dO/vzzTz744AOddCEhIejr63Po0CFWrVqVLZ+UlBQSExN1DiGEEEIUX/ISYSHq27cvkydPVkc6Dx06xHfffUdERISaJikpiRUrVrBu3To6dOgAZI4I7969mzVr1jB+/Hg17dy5c3F1dQVg0qRJdOzYkeTkZIyMjDA1NUVfXx8rKyudOjy7BFu1atWYPXs2n376KcuXLwdg6dKldOjQgXHjxgFQo0YNoqKi2LFjR4HamjXiDXDjxg1MTEzo1KkTZmZmVK1aNduoe04qV66c7dzjx48L1B7IfAt3+fLl1KtXT+feNm3aqO2EzJcIn7VixQoaNmzI559/rp5bu3YtNjY2XLp0iRo1agCZ61EHBgbm2o6AgABmzZqVe0OFEEIIUay8VAB98+ZNNBqNGgAdPXqUb7/9FicnJwYPHlyoFSxKypYtS8eOHQkJCUFRFDp27EjZsmV10ly5coXU1FRatGihnitZsiRNmjQhNjZWJ62zs7P6s7W1NQB37tzJc071/v37+fzzz4mJiSExMZG0tDSSk5NJSkrCxMSEixcv0q1bN517mjRpUuAA+lkeHh5UrVoVOzs7vLy88PLyolu3bhgb570CRWRkJGZmZjrnnp8m8qL2ABgYGOg8qywuLi55ln/ixAn279+PqalptmtXrlxRA+gX5TN58mSdjVcSExOxsbHJ8x4hhBBCFF0vNYWjV69e7N+/H4Dbt2/j4eHB0aNHmTJlCv7+/oVawaJmwIABrFu3jpCQkBynb2Qtu63RaLKdf/7cs2saZl3L6QW5LNevX8fb25s6deqwZcsWTpw4wX/+8x8gc5Q2t3KeXwpcT08v27ms+3NiZmbGyZMn2bRpE9bW1syYMYN69erluMrGs6pVq4a9vb3O8ewLfvlpD4CRkVG2NgFqgJ2bjIwMOnfuTHR0tM5x+fJlnSkoL8pHq9VSqlQpnUMIIYQQxddLBdDnzp2jSZMmAGzevJk6deoQFRXFt99+q/PV/rvIy8uLp0+f8vTpUzw9PbNdt7e3x8DAgIMHD6rnUlNTOX78eIG2qDYwMCA9PV3n3PHjx0lLSyMoKIimTZtSo0YN/vjjD500NWvW5OjRo9nue1a5cuWIj4/XOffsi3c50dfXp127dgQGBnLmzBni4uLYt29fvtuTk/y051U0bNiQ8+fPY2trmy2Qf1HQLIQQQoh310sF0KmpqWi1WgD27NlDly5dgMzg7PnA611TokQJYmNjiY2NpUSJEtmum5iY8OmnnzJ+/Hh27txJTEwMgwYN4vHjxwwcODDf5dja2nLt2jWio6O5e/cuKSkpVK9enbS0NJYuXcrVq1dZv349K1eu1LlvxIgRhIWFsXDhQi5fvsyqVav4+eefdUZw27Rpw/Hjx/nmm2+4fPkyM2fO5Ny5c7nWZceOHSxZsoTo6GiuX7/ON998Q0ZGBo6OjvluT07y055XMWzYMO7fv0/Pnj05evQoV69eZdeuXQwYMCDbHydCCCGEEFleag507dq1WblyJR07dmT37t3Mnj0bgD/++ANLS8tCrWBR9KKv8OfNm0dGRgZ9+/bl77//xsXFhfDwcEqXLp3vMnr06MHWrVtxd3fn4cOHBAcH4+vry8KFC/niiy+YPHkyrVu3JiAggH79+qn3tWjRgpUrVzJr1iymTZuGp6cnY8aMYdmyZWoaT09Ppk+fzoQJE0hOTmbAgAH069ePs2fP5lgXCwsLtm7dip+fH8nJyTg4OLBp0yZq166d7/bkpH79+i9sz6uoWLEihw4dYuLEiXh6epKSkkLVqlXx8vJCT+/VF6g5N8vztW3lfc7PU7aeLaKkD4s+6UMhhEZ5frJrPkRERNCtWzcSExPp378/a9euBWDKlClcuHBBZy1k8fYbNGgQFy5cIDIy8k1XpVhITEzE3NychISE1xZAe3t7yy/uIkr6sOiTPiwepB+LvsLuw4L8/n6pEWg3Nzfu3r1LYmKizqjp4MGDX7jygnjzFixYgIeHByYmJvz888+EhIToLAsnhBBCCCFy99LrQCuKwokTJ7hy5Qq9evXCzMwMAwMDCaCLgKNHjxIYGMjff/+NnZ0dS5Ys4eOPP84xra+vLw8fPiQ0NPSfrWQBuLm5Ub9+fRYvXvymq6Kjzsxw9LSF+9+DtoRCYBOo4xdOSnr2lUfE20/6sOh73X0YN69joecphChcLxVAX79+HS8vL27cuEFKSgoeHh6YmZkRGBhIcnJyob7oVZz4+voSEhICZK5aYWNjQ/fu3Zk1a9Y/uurD5s2b8532yy+/zLak3euQ0zJ0LVq00FmtRAghhBDibfBSAfSoUaNwcXHh9OnTOi8NduvWLdeRTJHJy8uL4OBgUlNTiYyM5OOPP1Z3JywoRVFIT0/XWTu5sKSnp6PRaDA3Ny/0vHMTHByMl5eX+tnAwOAfK1sIIYQQIr9eaqmBgwcPMm3atGwBTtWqVfn9998LpWLFlVarxcrKChsbG3r16kXv3r3V6RGKohAYGIidnR1GRkbUq1ePH3/8Ub03IiICjUZDeHg4Li4uaLVaIiMjX3gfwPbt23FwcMDIyAh3d3dCQkLQaDTqZifr1q3DwsKCHTt24OTkhFar5fr16/j6+tK1a1c1Hzc3N0aOHMmECRMoU6YMVlZW+Pn56ZSVkJDA4MGDKV++PKVKlaJNmzacPn36hc/GwsICKysr9ShTpgz37t2jZ8+eVK5cGWNjY+rWrcumTZvyzCclJYUJEyZgY2ODVqvFwcGBNWvWqNcPHDhAkyZN0Gq1WFtbM2nSJNLS0grURiGEEEK8u15q6DIjIyPHdXJv3bqVbWtmkTcjIyN1V71p06axdetWVqxYgYODA7/88gt9+vShXLlyuLq6qvdMmDCBBQsWYGdnh4WFxQvvi4uL4/3332fUqFF8/PHHnDp1inHjxmWry+PHjwkICODrr7/G0tKS8uXL51jnkJAQxo4dy5EjRzh8+DC+vr60aNECDw8PdQvzMmXKEBYWhrm5OatWraJt27ZcunSJMmXKFOj5JCcn06hRIyZOnEipUqX46aef6Nu3L3Z2drz33ns53tOvXz8OHz7MkiVLqFevHteuXePu3bsA/P7773h7e+Pr68s333zDhQsXGDRoEIaGhjpBcl5tfF5KSgopKSnq58TExAK1UQghhBBFy0sF0B4eHixevJivvvoKyJy/+ujRI2bOnIm3t3ehVrA4O3r0KN9++y1t27YlKSmJhQsXsm/fPpo1awaAnZ0dBw8eZNWqVToBtL+/vxrI5ee+lStX4ujoyPz58wFwdHTk3LlzzJ07V6c+qampLF++nHr16uVZb2dnZ2bOnAmAg4MDy5YtY+/evXh4eLB//37Onj3LnTt31M12FixYQGhoKD/++CODBw/ONd+ePXvqbD6zYcMGunbtqhPsjxgxgp07d/LDDz/kGEBfunSJzZs3s3v3btq1a6c+jyzLly/HxsaGZcuWodFoqFmzJn/88QcTJ05kxowZ6vrPebXxeQEBAcyaNSvPZyaEEEKI4uOlAuhFixbh7u6Ok5MTycnJ9OrVi8uXL1O2bNkXfr3+rtuxYwempqakpaWRmpqKj48PS5cuJSYmhuTk5GwB2tOnT2nQoIHOORcXF/Xn/Nx38eJFGjdurHM9ayv2ZxkYGODs7PzCNjyfxtramjt37gBw4sQJHj16lG1DnSdPnnDlypU88120aJEa9Gblm56ezrx58/j+++/5/fff1dHe3F66jI6OpkSJEjp/cDwrNjaWZs2a6by02KJFCx49esStW7eoUqXKC9v4vMmTJzN27Fj1c2JiIjY2Nnm2VQghhBBF10sF0BUrViQ6OppNmzZx8uRJMjIyGDhwIL1798bIyKiw61isuLu7s2LFCkqWLEnFihXVhb+vXbsGwE8//USlSpV07skayc3ybPCYkZHxwvsURcm2ykVOK2sYGRnluBrG855frFyj0aj1yMjIwNramoiIiGz3WVhY5JmvlZUV9vb2OucCAwNZtGgRixcvpm7dupiYmDB69GiePn2aYx4v+veX17N49nxebXyeVqvN1kdCCCGEKL5eevkGIyMjBgwYwIABAwqzPsWeiYlJtiARUF/cu3HjRq6jpznJz301a9YkLCxM59zx48cLVvF8atiwIbdv30ZfXx9bW9tXzi8yMhIfHx/69OkDZAboly9fplatWjmmr1u3LhkZGRw4cEBnNDuLk5MTW7Zs0Qmko6KiMDMzy/YHiBBCCCFETvIdQG/fvp0OHTpQsmRJtm/fnmfaLl26vHLF3jVmZmaMGzeOMWPGkJGRQcuWLUlMTCQqKgpTU1P69+//0vd98sknLFy4kIkTJzJw4ECio6NZt24dkPP6y6+iXbt2NGvWjK5du/LFF1/g6OjIH3/8QVhYGF27dtWZfpIf9vb2bNmyhaioKEqXLs3ChQu5fft2rgG0ra0t/fv3Z8CAAepLhNevX+fOnTt88MEHDB06lMWLFzNixAiGDx/OxYsXmTlzJmPHjlXnPwshhBBC5CXfAXTXrl25ffs25cuX11nW7HkajSbHFTrEi82ePZvy5csTEBDA1atXsbCwoGHDhkyZMuWV7qtWrRo//vgjn332GV9++SXNmjVj6tSpfPrpp4U+9UCj0RAWFsbUqVMZMGAAf/31F1ZWVrRu3ZoKFSoUOL/p06dz7do1PD09MTY2ZvDgwXTt2pWEhIRc71mxYgVTpkxh6NCh3Lt3jypVqqjPolKlSoSFhTF+/Hjq1atHmTJlGDhwINOmTXvpNufm3CxPSpUqVah5pqamEhYWxjk/z2zTTETRIH1Y9EkfCiE0yj+xzZx468ydO5eVK1dy8+bNN12VYicxMRFzc3MSEhJeWwDt7e0tv7iLKOnDok/6sHiQfiz6CrsPC/L7u/C3sBNvnJubG/Xr12fx4sXqueXLl9O4cWMsLS05dOgQ8+fPZ/jw4W+ukgWQU3teN41Gw7Zt2/L8tuVF6swMR09rXHiVArQlFAKbQB2/cFLSC3f6jfhnSB8Wfa+rD+PmdSy0vIQQr9dLTfocOXIkS5YsyXZ+2bJljB49+lXrVCT4+vqi0WiyHc9uRf2mbN26ldmzZ+ucu3z5Mj4+Pjg5OTF79mw+++yzQtldb//+/XTq1Ily5cphaGhI9erV+fDDD/nll19eOW8hhBBCiLfRSwXQW7ZsoUWLFtnON2/ePNsW0sWZl5cX8fHxOserrIOtKIrOltIvq0yZMtl2hFy0aBF//PEHycnJXLp0ienTp6Ov/2pfQCxfvpy2bdtiaWnJ999/T2xsLOvXr6d58+aMGTPmlfIWQgghhHhbvVQAfe/ePczNzbOdL1WqlLpl8rtAq9ViZWWlc5QuXRqAuLg4NBoN0dHRavqHDx+i0WjUNZIjIiLQaDSEh4fj4uKCVqslMjKSK1eu4OPjQ4UKFTA1NaVx48bs2bNHp+zly5fj4OCAoaEhFSpU4P3331evubm56XwTsGHDBlxcXDAzM8PKyopevXrpbAqSVY+9e/fi4uKCsbExzZs35+LFi7m2/caNG4wePZrRo0cTEhJCmzZtqFatGs2bN2fUqFHZlsnbsmULtWvXRqvVYmtrS1BQUL7bA5nL102YMIEyZcpgZWWVbfR84cKF6jrRNjY2DB06lEePHgGZf5iUK1eOLVu2qOnr16+vs1X54cOHKVmypHrP8/z9/alQoYJOfwohhBDi3fRSAbS9vT07d+7Mdv7nn3/W2TZZ5M+ECRMICAggNjYWZ2dnHj16hLe3N3v27OHUqVN4enrSuXNnbty4AWSu4Txy5Ej8/f25ePEiO3fupHXr1rnm//TpU2bPns3p06cJDQ3l2rVr+Pr6Zks3depUgoKCOH78OPr6+nmu8b1lyxZSU1OZMGFCjtefXR7vxIkTfPDBB/z73//m7Nmz+Pn5MX36dHUpvfy0JyQkBBMTE44cOUJgYCD+/v7s3r1bva6np8eSJUs4d+4cISEh7Nu3T62bRqOhdevW6h8uDx48ICYmhtTUVGJiYoDMPyIaNWqEqampTrmKojBq1CjWrFnDwYMHqV+/fra2pqSkkJiYqHMIIYQQovh6qe/wx44dy/Dhw/nrr79o06YNAHv37iUoKOgffdHrTcvalvtZEydOZPr06QXKx9/fX2crbktLS+rVq6d+njNnDtu2bWP79u0MHz6cGzduYGJiQqdOnTAzM6Nq1arZtvt+1rOBsJ2dHUuWLKFJkyY8evRIp/5z585VN2OZNGkSHTt2JDk5GUNDw2x5Xrp0iVKlSmFlZaWe27Jli8561YcPH6Zu3bosXLiQtm3bqs+lRo0axMTEMH/+fHx9ffPVHmdnZ2bOnAmAg4MDy5YtY+/evepze3bEvVq1asyePZtPP/2U5cuXA5mj8l999RUAv/zyC/Xq1aNKlSpERETg5OREREQEbm5uOmWmpaXRr18/jh8/zqFDh6hcuXKOzzcgIIBZs2bleE0IIYQQxc9LjUAPGDCAoKAg1qxZg7u7O+7u7mzYsIEVK1YwaNCgwq7jW8vd3Z3o6GidY9iwYQXO5/nNRZKSkpgwYQJOTk5YWFhgamrKhQsX1BFoDw8Pqlatip2dHX379mXjxo08fvw41/xPnTqFj48PVatWxczMTA0Us/LL4uzsrP5sbW0NoDPV43nPb8Li6elJdHQ0P/30E0lJSep64LGxsdnmzLdo0YLLly+Tnp6er/Y8W7es+j1bt/379+Ph4UGlSpUwMzOjX79+3Lt3j6SkJCAzgD5//jx3797lwIEDuLm54ebmxoEDB0hLSyMqKirbTo5jxozh8OHDREZG5ho8A0yePJmEhAT1kKUBhRBCiOLtpbde+/TTT7l16xZ//vkniYmJXL16lX79+hVm3d56WdtyP3uUKVMGQN3V7tlltlNTU3PN51njx49ny5YtzJ07l8jISKKjo6lbty5Pnz4FMncfPHnyJJs2bcLa2poZM2ZQr149Hj58mC3vpKQk2rdvj6mpKRs2bODYsWNs27YNQM0vy7NrKGYFxxkZGTnW2cHBgYSEBG7fvq2eMzU1xd7enqpVq+qkfXbb7GfPZclPe55f31Gj0ah1u379Ot7e3tSpU4ctW7Zw4sQJ/vOf/wD//8zr1KmDpaUlBw4cUANoV1dXDhw4wLFjx3jy5AktW7bUKcPDw4Pff/+d8PDwHJ9BFq1WS6lSpXQOIYQQQhRfLx1Ap6WlsWfPHrZu3aoGQ3/88UeuL2G9a8qVKwdAfHy8ei6/L6BFRkbi6+tLt27dqFu3LlZWVsTFxemk0dfXp127dgQGBnLmzBni4uLYt29ftrwuXLjA3bt3mTdvHq1ataJmzZp5jirn1/vvv0/JkiX54osvXpjWycmJgwcP6pyLioqiRo0alChRokDtycnx48dJS0sjKCiIpk2bUqNGDf744w+dNFnzoP/73/9y7tw5WrVqRd26dUlNTWXlypU0bNgw28olXbp04dtvv+Xjjz/mu+++y1ddhBBCCFH8vdQc6OvXr+Pl5cWNGzdISUnBw8MDMzMzAgMDSU5OZuXKlYVdz7dSSkqKzggsZAaCZcuWxcjIiKZNmzJv3jxsbW25e/duvreLtre3Z+vWrXTu3BmNRsP06dN1RoJ37NjB1atXad26NaVLlyYsLIyMjAwcHR2z5VWlShUMDAxYunQpQ4YM4dy5c9nWiH4ZVapUISgoiFGjRnH//n18fX2pVq0a9+/fZ8OGDQBqcPzZZ5/RuHFjZs+ezYcffsjhw4dZtmyZOj+5IO3JSfXq1UlLS2Pp0qV07tyZQ4cO5fhv0M3NjTFjxtCgQQN1lLh169Zs3LiRsWPH5ph3t27dWL9+PX379kVfXz/b6iBCCCGEeAcpL8HHx0fp06ePkpKSopiamipXrlxRFEVRIiIiFHt7+5fJssjp37+/AmQ7HB0d1TQxMTFK06ZNFSMjI6V+/frKrl27FEDZv3+/oiiKsn//fgVQHjx4oJP3tWvXFHd3d8XIyEixsbFRli1bpri6uiqjRo1SFEVRIiMjFVdXV6V06dKKkZGR4uzsrHz//ffq/c+mVRRF+fbbbxVbW1tFq9UqzZo1U7Zv364AyqlTp3Ktx6lTpxRAuXbtWp7PYffu3UqHDh2UMmXKKPr6+kqFChWUrl27Kjt37tRJ9+OPPypOTk5KyZIllSpVqijz589XrxW0PYqS+W+wf//+6ueFCxcq1tbWipGRkeLp6al888032dp09uxZBVDGjRunnlu0aJECKDt27NDJH1C2bdumfv7+++8VQ0NDZcuWLXk+D0VRlISEBAVQEhISXpi2oJ4+faqEhoYqT58+LfS8xT9D+rDokz4sHqQfi77C7sOC/P7WKMozk1HzqWzZshw6dAhHR0fMzMw4ffo0dnZ2xMXF4eTklOcLbUIUd4mJiZibm5OQkFDo86FTU1MJCwvD29s727xwUTRIHxZ90ofFg/Rj0VfYfViQ398vNQc6IyNDXWHhWbdu3co2j1QIIYQQQoji5KXmQHt4eLB48WJ1XV2NRsOjR4+YOXMm3t7ehVrBgtBoNGzbto2uXbu+sTr8k+Li4qhWrRqnTp3KcYOPf5Kbmxv169cvkuuA+/n5ERoaWui7DNaZGY6e1rhQ89SWUAhsAnX8wklJ17z4BvHWkT4s+vLqw7h5Hd9QrYQQ/6SXGoFetGgRBw4cwMnJieTkZHr16oWtrS2///57vlZleBl37tzhk08+oUqVKuoW2p6enhw+fPi1lPc8jUZDaGjoC9P5+vq+VQH81atX6dmzJxUrVsTQ0JDKlSvj4+PDpUuX3nTVXsjX1xeNRpPt8PLyetNVE0IIIcQ77KVGoCtWrEh0dDSbNm3i5MmTZGRkMHDgQHr37o2RkVFh1xGAHj16kJqaSkhICHZ2dvz555/s3buX+/fvv5bysjx9+hQDA4PXWsbr8vTpUzw8PKhZsyZbt27F2tqaW7duERYWRkJCwpuuXr54eXkRHBysc06r1b6h2gghhBBCvMI60EZGRgwYMEBdjuzjjz9+bcHzw4cPOXjwIF988QXu7u5UrVqVJk2aMHnyZDp21P267O7du3Tr1g1jY2McHBzYvn27zvUDBw7QpEkTtFot1tbWTJo0ibS0NPW6m5sbw4cPZ+zYsZQtWxYPDw9sbW2BzCXNNBqN+vl5fn5+hISE8N///lcdLY2IiADg7NmztGnTBiMjIywtLRk8eHC2NbODg4OpVasWhoaG1KxZU13mLcvRo0dp0KABhoaGuLi4cOrUqTyfW0xMDFevXmX58uU0bdqUqlWr0qJFC+bOnUvjxo2BzGkgGo2GrVu34u7ujrGxMfXq1dMZ2b937x49e/akcuXKGBsbU7duXTZt2pRn2Tt37sTc3JxvvvkGgN9//50PP/yQ0qVLY2lpiY+PT7a1rXOS9W3Ds0fp0qXV6wsXLqRu3bqYmJhgY2PD0KFDsz3X1atXY2Njg7GxMd26dWPhwoVYWFjkWe6L+kIIIYQQ766XDqAvXrzI8OHDadu2Le3atWP48OFcuHChMOumMjU1xdTUlNDQUFJSUvJMO2vWLD744APOnDmDt7c3vXv3Vkepf//9d7y9vWncuDGnT59mxYoVrFmzhjlz5ujkERISgr6+PocOHWLVqlUcO3YMyAyq4uPj1c/PGzduHB988AFeXl7Ex8cTHx9P8+bNefz4MV5eXpQuXZpjx47xww8/sGfPHoYPH67eu3r1aqZOncrcuXOJjY3l888/Z/r06YSEhACZOwp26tQJR0dHTpw4gZ+fH+PGjcvzWZQrVw49PT1+/PHHHF/6fNbUqVMZN24c0dHR1KhRg549e6p/WCQnJ9OoUSN27NjBuXPnGDx4MH379uXIkSM55vXdd9/xwQcf8M0339CvXz8eP36Mu7s7pqam/PLLLxw8eBBTU1O8vLyy7YZYUHp6eixZsoRz584REhLCvn37mDBhgnr90KFDDBkyhFGjRhEdHY2Hhwdz587NM88X9cXzUlJSSExM1DmEEEIIUXy9VAD9448/UqdOHU6cOEG9evVwdnbm5MmT1K1blx9++KGw64i+vj7r1q0jJCQECwsLWrRowZQpUzhz5ky2tL6+vvTs2RN7e3s+//xzkpKSOHr0KADLly/HxsaGZcuWUbNmTbp27cqsWbMICgrS2ajE3t6ewMBAHB0dqVmzprqroIWFBVZWVurn55mammJkZKQzampgYMDGjRt58uQJ33zzDXXq1KFNmzYsW7aM9evX8+effwIwe/ZsgoKC6N69O9WqVaN79+6MGTOGVatWAbBx40bS09NZu3YttWvXplOnTowfPz7P51apUiWWLFnCjBkzKF26NG3atGH27NlcvXo1W9px48bRsWNHatSowaxZs7h+/Tq//fabms+4ceOoX78+dnZ2jBgxAk9Pzxz7evny5QwZMoT//ve/+Pj4AJkBtZ6eHl9//TV169alVq1aBAcHc+PGDXWEPjc7duxQ/4DKOp7dCGb06NG4u7tTrVo1tX2bN29Wry9dupQOHTowbtw4atSowdChQ+nQoUOeZb6oL54XEBCAubm5etjY2OSZvxBCCCGKtpcKoCdMmMDkyZM5fPgwCxcuZOHChURFRTFlyhQmTpxY2HUEMudA//HHH2zfvh1PT08iIiJo2LAh69at00nn7Oys/mxiYoKZmZm6dXVsbCzNmjVDo/n/t6ZbtGjBo0ePuHXrlnrOxcXlhfW5ceOGTlD3+eef55o2NjaWevXqYWJiolNuRkYGFy9e5K+//uLmzZsMHDhQJ885c+Zw5coVnTyMjf9/VYdmzZq9sJ7Dhg3j9u3bbNiwgWbNmvHDDz9Qu3Ztdu/erZPu2edmbW0NoD639PR05s6di7OzM5aWlpiamrJr1y5u3Lihk8eWLVsYPXo0u3btwt3dXT1/4sQJfvvtN8zMzNS2lSlThuTkZK5cuUJkZKROuzdu3Kje6+7uTnR0tM4xbNgw9fr+/fvx8PCgUqVKmJmZ0a9fP+7du0dSUhKQ+U1JkyZNdOr5/Odn5acvnjd58mQSEhLU4+bNm7nmL4QQQoii76VeIrx9+zb9+vXLdr5Pnz7Mnz//lSuVG0NDQzw8PPDw8GDGjBl8/PHHzJw5E19fXzXN8wtpazQadXRZURSd4DnrXFa6LM8GurnJepEyS5kyZXJNm1O5OdVv9erVvPfeezrXs7bDfon9blRmZmZ06dKFLl26MGfOHDw9PZkzZw4eHh5qmmefW1Zds+oVFBTEokWLWLx4sTrfePTo0dmmX9SvX5+TJ08SHBxM48aNdfJp1KiRTmCcpVy5chgYGOg8ywoVKqg/m5iYYG9vn2O7rl+/jre3N0OGDGH27NmUKVOGgwcPMnDgQFJTU4G8+zwn+emL52m1WnmxUQghhHiHvFQA7ebmRmRkZLbA5uDBg7Rq1apQKpYfTk5O+Vpa7tn0W7Zs0QmqoqKiMDMzo1KlSnneW7JkSZ15xPr6+jkGdgYGBtnmGzs5ORESEkJSUpIanB86dAg9PT1q1KhBhQoVqFSpElevXqV379651n39+vU8efJEfVnz119/zXfbs2g0GmrWrElUVFS+74mMjMTHx4c+ffoAmUHm5cuXqVWrlk666tWrExQUhJubGyVKlGDZsmUANGzYkO+//57y5cvnurNPbkFyXo4fP05aWhpBQUHo6WV+mfLs9A2AmjVrqlN4nr0vN/npCyGEEEK8215qCkeXLl2YOHEiw4cPZ8OGDWzYsIHhw4czadIkunXrxvbt29WjMNy7d482bdqwYcMGzpw5w7Vr1/jhhx8IDAxU59nmx9ChQ7l58yYjRozgwoUL/Pe//2XmzJmMHTtWDcByY2try969e7l9+zYPHjzIM92ZM2e4ePEid+/eJTU1ld69e2NoaEj//v05d+4c+/fvZ8SIEfTt21cdbfXz8yMgIIAvv/ySS5cucfbsWYKDg1m4cCEAvXr1Qk9Pj4EDBxITE0NYWBgLFizIs87R0dH4+Pjw448/EhMTw2+//caaNWtYu3ZtgZ6bvb09u3fvJioqitjYWD755BNu376dY9oaNWqwf/9+dToHQO/evSlbtiw+Pj5ERkZy7do1Dhw4wKhRo3SmzuQkJSWF27dv6xx3794FMgP2tLQ0li5dytWrV1m/fj0rV67UuX/EiBGEhYWxcOFCLl++zKpVq/j5559z/UYAXtwXQgghhHjHKS9Bo9Hk69DT03uZ7LNJTk5WJk2apDRs2FAxNzdXjI2NFUdHR2XatGnK48eP1XSAsm3bNp17zc3NleDgYPVzRESE0rhxY8XAwECxsrJSJk6cqKSmpqrXXV1dlVGjRmWrw/bt2xV7e3tFX19fqVq1aq51vXPnjuLh4aGYmpoqgLJ//35FURTlzJkziru7u2JoaKiUKVNGGTRokPL333/r3Ltx40alfv36ioGBgVK6dGmldevWytatW9Xrhw8fVurVq6cYGBgo9evXV7Zs2aIAyqlTp3Ksy19//aWMHDlSqVOnjmJqaqqYmZkpdevWVRYsWKCkp6criqIo165dy5bHgwcPdOp+7949xcfHRzE1NVXKly+vTJs2TenXr5/i4+OT63OLiYlRypcvr4wdO1ZRFEWJj49X+vXrp5QtW1bRarWKnZ2dMmjQICUhISHXZ9m/f38FyHY4OjqqaRYuXKhYW1srRkZGiqenp/LNN98ogPLgwQM1zVdffaVUqlRJMTIyUrp27arMmTNHsbKyUq/PnDlTqVevXoH6Ii8JCQkKkGfbXtbTp0+V0NBQ5enTp4Wet/hnSB8WfdKHxYP0Y9FX2H1YkN/fGkV5hcm1QhRBgwYN4sKFC0RGRr6W/BMTEzE3NychISHXKSsvKzU1lbCwMLy9vbPN9xdFg/Rh0Sd9WDxIPxZ9hd2HBfn9XaA50EeOHOH+/fs6y4B98803zJw5k6SkJLp27crSpUvlhaoizM/Pj9DQUJ2X+p7n6+vLw4cPCzT//E1asGABHh4emJiY8PPPPxMSEqKzMYqtrS2jR49Wp5wUljozw9HTGr84YQFoSygENoE6fuGkpOc+DUW8vaQPi464eR1fnEgI8U4q0BxoPz8/nbWXz549y8CBA2nXrh2TJk3if//7HwEBAYVeSfFit2/fZtSoUdjb22NoaEiFChVo2bIlK1eu5PHjx2+6ei8lazfH54/vvvuuQPkcPXoUDw8P6taty8qVK1myZAkff/zxa6q1EEIIIYq7Ao1AR0dH62xi8d133/Hee++xevVqAGxsbJg5cyZ+fn6FWkmRt6tXr9KiRQssLCz4/PPPqVu3LmlpaVy6dIm1a9dSsWJFunTp8qar+VKCg4Px8vLSOfeibbif9/zKHEIIIYQQr6JAI9APHjzQWaP3wIEDOsFN48aNZROJN2Do0KHo6+tz/PhxPvjgA2rVqkXdunXp0aMHP/30E507d1bT3rhxAx8fH0xNTSlVqhQffPCBuhtiTtLT0xk7diwWFhZYWloyYcKEbOsoK4pCYGAgdnZ2GBkZUa9ePX788Uf1ekREBBqNhr179+Li4oKxsTHNmzfn4sWLL2xb1u6Pzx6GhoZA5uosPXv2pHLlyhgbG1O3bl02bdqkc//ff/9N7969MTExwdramkWLFuHm5pbndI2EhAQGDx6sLrvXpk0bTp8+/cK6CiGEEOLdUKAAukKFCly7dg2Ap0+fcvLkSZ3d8P7++2+ZiP8Pu3fvHrt27WLYsGG5bgCTtWSboih07dqV+/fvc+DAAXbv3s2VK1f48MMPc80/KCiItWvXsmbNGg4ePMj9+/fZtm2bTppp06YRHBzMihUrOH/+PGPGjKFPnz4cOHBAJ93UqVMJCgri+PHj6OvrM2DAgFdqe3JyMo0aNWLHjh2cO3eOwYMH07dvX44cOaKmGTt2LIcOHWL79u3s3r2byMhITp48mWueiqLQsWNHbt++TVhYGCdOnKBhw4a0bduW+/fv53hPSkoKiYmJOocQQgghiq8CTeHw8vJi0qRJfPHFF4SGhmJsbKyzccqZM2eoXr16oVdS5O63335DURQcHR11zpctW5bk5GQgczvvL774gj179qjraNvY2ACwfv16ateuzbFjx2jcuHG2/BcvXszkyZPp0aMHACtXriQ8PFy9npSUxMKFC9m3b5/6x5SdnR0HDx5k1apVuLq6qmnnzp2rfp40aRIdO3YkOTlZHVHOSc+ePbPtAHjmzBns7OyoVKkS48aNU8+PGDGCnTt38sMPP/Dee+/x999/ExISwrfffkvbtm2BzCkhFStWzLW8/fv3c/bsWe7cuaO+DLtgwQJCQ0P58ccfGTx4cLZ7AgICmDVrVq55CiGEEKJ4KVAAPWfOHLp3746rqyumpqaEhIRgYGCgXl+7di3t27cv9EqKF3t+Y5CjR4+SkZFB7969SUlJASA2NhYbGxs1eIbMHQ4tLCyIjY3NFkAnJCQQHx+v8y2Dvr4+Li4u6jSOmJgYkpOTdbYFh8xvKBo0aKBzztnZWf3Z2toagDt37lClSpVc27Vo0SLatWuncy6r/unp6cybN4/vv/+e33//nZSUFFJSUtSR+KtXr5KamkqTJk3Ue83NzbP9sfGsEydO8OjRIywtLXXOP3nyhCtXruR4z+TJkxk7dqz6OTExUecZCyGEEKJ4KVAAXa5cOSIjI0lISMDU1DTbyOAPP/yAqalpoVZQ5M3e3h6NRsOFCxd0ztvZ2QGo234DOluYPyu38/mRkZEBwE8//ZRtO/TnlzN8dnpPVnlZ9+fGysoq122+g4KCWLRoEYsXL6Zu3bqYmJgwevRonj59CqAG+c+3La+lzzMyMrC2tiYiIiLbtdxeXtRqtbJ0oxBCCPEOeamtvM3NzbMFzwBlypTRGZEWr5+lpSUeHh4sW7aMpKSkPNM6OTlx48YNnRc9Y2JiSEhIoFatWtnSm5ubY21tza+//qqeS0tL48SJEzp5arVabty4gb29vc7xukdhIyMj8fHxoU+fPtSrVw87OzsuX76sXq9evTolS5bk6NGj6rnExESdNM9r2LAht2/fRl9fP1t7ypYt+1rbI4QQQoiioUAj0OLttHz5clq0aIGLiwt+fn44Ozujp6fHsWPHuHDhAo0aNQKgXbt2ODs707t3bxYvXkxaWhpDhw7F1dUVFxeXHPMeNWoU8+bNw8HBgVq1arFw4UIePnyoXjczM2PcuHGMGTOGjIwMWrZsSWJiIlFRUZiamtK/f/9XatvDhw+5ffu2zjkzMzNMTEywt7dny5YtREVFUbp0aRYuXMjt27fVPwbMzMzo378/48ePp0yZMpQvX56ZM2eip6eX64h7u3btaNasGV27duWLL77A0dGRP/74g7CwMLp27ZrrcxJCCCHEu0MC6GKgevXqnDp1is8//5zJkydz69YttFotTk5OjBs3jqFDhwKZUxlCQ0MZMWIErVu3Rk9PDy8vL5YuXZpr3p999hnx8fH4+vqip6fHgAED6NatGwkJCWqa2bNnU758eQICArh69SoWFhY0bNiQKVOmvHLbPvroo2znAgICmDRpEtOnT+fatWt4enpibGzM4MGD6dq1q07dFi5cyJAhQ+jUqROlSpViwoQJ3Lx5M9cXFzUaDWFhYUydOpUBAwbw119/YWVlRevWrXWWcMyPc7M8X9tW3uf8PGXFmyJK+lAIIYo+jZLXhFAhipmkpCQqVapEUFAQAwcOfC1lJCYmYm5uTkJCwmsLoL29vSX4KqKkD4s+6cPiQfqx6CvsPizI728ZgRbF2qlTp7hw4QJNmjQhISEBf39/AHx8fN5wzYQQQghRVEkALd6IuLg4qlWrxqlTp6hfv/5rLWvBggVcvHgRAwMDGjVqRGRkpM4Lgb6+vjx8+JDQ0NBCLbfOzHD0tMaFmqe2hEJgE6jjF05K+sutnCLerHehD+PmdXzTVRBCiNfqpVbhEG8XX19fNBqNelhaWuLl5cWZM2cKtZy4uDg0Gg3R0dGFmm9u3NzcdNqVdQwZMiTfeTRo0EBd2/n+/fvs3r2bunXrvsZaCyGEEKK4kwC6mPDy8iI+Pp74+Hj27t2Lvr4+nTp1etPVemWDBg1S25V1BAYGvulqCSGEEOIdJgF0MaHVarGyssLKyor69eszceJEbt68yV9//aWmOXv2LG3atMHIyAhLS0sGDx7Mo0eP1OsZGRn4+/tTuXJltFot9evXZ+fOner1atWqAZmjuhqNBjc3N/VacHAwtWrVwtDQkJo1a7J8+XKd+h09epQGDRpgaGiIi4sLp06dyle7jI2N1XZlHc9O7J84cSI1atTA2NgYOzs7pk+fTmpqqk4ec+bMoXz58piZmfHxxx8zadKkPKeNKIpCYGAgdnZ2GBkZUa9ePX788cd81VcIIYQQxZ/MgS6GHj16xMaNG7G3t1e3pH78+DFeXl40bdqUY8eOcefOHT7++GOGDx/OunXrAPjyyy8JCgpi1apVNGjQgLVr19KlSxfOnz+Pg4MDR48epUmTJuzZs4fatWurm+asXr2amTNnsmzZMho0aMCpU6cYNGgQJiYm9O/fn6SkJDp16kSbNm3YsGED165dY9SoUYXSVjMzM9atW0fFihU5e/YsgwYNwszMjAkTJgCwceNG5s6dq66V/d133xEUFKT+MZCTadOmsXXrVlasWIGDgwO//PILffr0oVy5cri6umZLn7WFeJbExMRCaZsQQggh3k4SQBcTO3bsULdRT0pKwtramh07dqCnl/klw8aNG3ny5AnffPMNJiYmACxbtozOnTvzxRdfUKFCBRYsWMDEiRP597//DcAXX/xfe3ce11P2/wH89an0af9EaaG0SCVLiywVKjOJBlkGY0LJmLGvCWOphGREtmxDNRjLoMbSZC2TsqbElCISI2KkVNP6Ob8/+nW/rhZFpOb9fDzu49E999xzzv2cGZ93p3PP8UdUVBQCAwOxZcsWtG7dGkDF7ocaGhpc3b6+vggICMDw4cMBVIxUJycnY/v27XB1dcW+fftQXl6O3bt3Q05ODp06dcLjx48xZcqUdz5XUFAQfv75Z17ali1buA1alixZwqXr6upi3rx5OHjwIBdAb9q0CRMnTuTWk162bBlOnz7NG3l/U0FBAdatW4fz58/DysoKQMW26BcvXsT27durDaD9/Pzg4+PzzmchhBBCSPNAAXQzYW9vj61btwIAXr58iaCgIAwcOBBXr16Fjo4OUlJSYGpqygXPAGBjYwOxWIzU1FTIysriyZMnsLGx4ZVrY2ODmzdv1ljv8+fP8ejRI0ycOBGTJk3i0svKyiASiQCAq1tO7n8rUlQGp+/i4uKCxYsX89LU1NS4nw8fPozAwEDcu3cP+fn5KCsr403xSE1N5TaSqdSjRw+cP3++2vqSk5NRVFQEBwcHXnpJSQnMzc2rvWfRokWYO3cud56Xl/fRtzEnhBBCSOOhALqZqNzaulK3bt0gEomwc+dOrFixAoyxGrevfjP97Ty13QdUzJsGKqZx9OzZk3dNUlKSK+N9iUQi3nO96fLly/jmm2/g4+MDR0dHiEQiborGm6p7pppUPs/JkyfRtm1b3jWhUFjtPUKhsMZrhBBCCGl+KIBupgQCASQkJPDvv/8CAExMTBAaGoqCggJuFDo2NhYSEhIwNDSEkpIS2rRpg4sXL6Jv375cOXFxcejRowcAcHOey8vLuevq6upo27Yt7t+/DxcXl2rbYmJigj179uDff/+FrKwsgIrg90PFxsZCR0eHN0L98OFDXh4jIyNcvXoV48aN49KuX79eY5kmJiYQCoXIzMysdroGIYQQQggF0M1EcXExnj59CgDIycnB5s2bkZ+fj8GDBwOomArh5eUFV1dXeHt74/nz55gxYwbGjRsHdXV1AMD8+fPh5eWF9u3bw8zMDMHBwUhMTMS+ffsAVEydkJWVRWRkJLS0tCAjIwORSARvb2/MnDkTSkpKGDhwIIqLi3H9+nXk5ORg7ty5+Pbbb7F48WJMnDgRS5YsQUZGBtauXVun5yosLOSeq5JQKETLli1hYGCAzMxMHDhwAN27d8fJkycRFhbGyztjxgxMmjQJlpaWsLa2xsGDB5GUlAR9ff1q61NUVISHhwfmzJkDsViM3r17Iy8vD3FxcVBQUODmXhNCCCHkP4yRJs/V1ZUB4A5FRUXWvXt3dvjwYV6+pKQkZm9vz2RkZFirVq3YpEmT2OvXr7nr5eXlzMfHh7Vt25a1aNGCmZqasj/++INXxs6dO5m2tjaTkJBgtra2XPq+ffuYmZkZk5aWZi1btmR9+/ZlR48e5a5funSJmZqaMmlpaWZmZsaOHDnCALCEhIQan8vW1pb3XJWHo6Mjl2f+/PlMRUWFKSgosNGjR7P169czkUjEK2f58uVMVVWVKSgoMHd3dzZz5kzWq1cv3ufn7OzMnYvFYrZhwwZmZGTEWrRowVq3bs0cHR3ZhQsXausGTm5uLgPAcnNz65S/PkpKSlh4eDgrKSlp8LLJp0F92PRRHzYP1I9NX0P3YX2+vwWMfcAEVUKaIAcHB2hoaGDPnj0fpfy8vDyIRCLk5ubyXmhsCKWlpYiIiICTkxNatGjRoGWTT4P6sOmjPmweqB+bvobuw/p8f9MUDtJo3Nzc8OrVK4SHh3+0OgoLC7Ft2zY4OjpCUlIS+/fvx9mzZ3HmzBkuT0ZGBvT09JCQkFDrBiv11dnrFCSEcu/OWA9CSYY1PYDO3qdQXF7zy53k8/W59mHG6q8auwmEENJkNLudCJ8+fYpZs2bBwMAAMjIyUFdXR+/evbFt2zYUFhZ+9PpDQkKgrKz8Ues4cuQIevbsCZFIBEVFRXTq1Anz5s1r0DoyMjIgEAiQmJjIS3dzc8PQoUMbtK6aREdHQyAQVHu8PS+6JgKBABEREejTpw+6deuG48eP48iRI/jyyy8/cusJIYQQ0lw1qxHo+/fvw8bGBsrKyli1ahW6dOmCsrIypKWlYffu3WjTpg2GDBlS7b2lpaWf1Z9wysvLuZU03nT27Fl88803WLVqFYYMGQKBQIDk5GScO3eukVr68aWmplb5U8qba0HXRlZWFmfPnv0YzSKEEELIf1SzGoGeOnUqpKSkcP36dYwaNQodO3ZEly5dMGLECJw8eZJbkQKoGJnctm0bnJ2dIS8vjxUrVgAAjh8/jm7dukFGRgb6+vrw8fFBWVkZd9+6devQpUsXyMvLQ1tbG1OnTuV2tYuOjsaECROQm5vLjZR6e3sDqNiIw9PTE23btoW8vDx69uyJ6OhortzKkesTJ05wS6m9vSQbULHjYO/evTF//nwYGRnB0NAQQ4cOxaZNm7g83t7eMDMzw/bt26GtrQ05OTmMHDkSr1694vKIxWIsX74cWlpaEAqFMDMzQ2RkJHe9cqtrc3NzCAQC2NnZwdvbG6Ghofj999+556t8hr///hujR49Gy5YtoaKiAmdnZ2RkZHDllZeXY+7cuVBWVoaKigo8PT3rvD60mpoaNDQ0eEflLxbXrl2Dg4MDVFVVIRKJYGtrixs3bvDuv3PnDnr37g0ZGRmYmJjg7NmzEAgEtU4dSU5OhpOTExQUFKCuro5x48bhxYsXdWovIYQQQpq3ZhNA//PPPzh9+jSmTZvG223vTW9vqOHl5QVnZ2fcunUL7u7uOHXqFMaOHYuZM2dyW1GHhIRg5cqV3D0SEhLYuHEjbt++jdDQUJw/f57bNtra2hqBgYFQUlJCVlYWsrKy4OHhAQCYMGECYmNjceDAASQlJWHkyJEYMGAA7t69y5VdWFgIPz8//Pzzz/jrr7+qHWXV0NDAX3/9hdu3b9f6edy7dw+HDh3C8ePHERkZicTEREybNo27vmHDBgQEBGDt2rVISkqCo6MjhgwZwrXn6tWrACpGvLOysnD06FF4eHhg1KhRGDBgAPd81tbWKCwshL29PRQUFPDnn3/i4sWLUFBQwIABA1BSUgIACAgIwO7du7Fr1y5cvHgRL1++rLLk3Pt4/fo1XF1dERMTg8uXL6NDhw5wcnLC69evAVT8ojB06FDIycnhypUr2LFjR5WdDd+WlZUFW1tbmJmZ4fr164iMjMSzZ88watSoavMXFxcjLy+PdxBCCCGk+Wo2Uzju3bsHxhiMjIx46aqqqigqKgIATJs2Df7+/ty1b7/9Fu7u7tz5uHHjsHDhQm6tX319ffj6+sLT0xNeXl4AgNmzZ3P59fT04OvriylTpiAoKAjS0tIQiUQQCATQ0NDg8qWnp2P//v14/Pgx2rRpAwDw8PBAZGQkgoODsWrVKgAV00iCgoJgampa43POmDEDMTEx6NKlC3R0dNCrVy/0798fLi4uvN3wioqKEBoaCi0tLQDApk2b8NVXXyEgIAAaGhpYu3YtFixYgG+++QYA4O/vj6ioKAQGBmLLli1o3bo1AEBFRYX3LLKysiguLual7d27FxISEvj555+5X1KCg4OhrKyM6Oho9O/fH4GBgVi0aBFGjBgBANi2bRtOnTpV43O+qfIZKrVt2xapqakAgH79+vGubd++HS1btsSFCxcwaNAgnD59Gunp6YiOjubavHLlyipbdb9p69atsLCw4PoFAHbv3g1tbW2kpaXB0NCQl9/Pzw8+Pj51ehZCCCGENH3NJoCu9PYo89WrVyEWi+Hi4oLi4mLeNUtLS955fHw8rl27xhtxLi8vR1FREQoLCyEnJ4eoqCisWrUKycnJyMvLQ1lZGYqKing7/L3txo0bYIxVCbyKi4uhoqLCnUtLS6Nr1661Pp+8vDxOnjyJ9PR0REVF4fLly5g3bx42bNiAS5cuQU6uYtWHdu3a8QJPKysriMVipKamQk5ODk+ePIGNjQ2vbBsbG9y8ebPW+qsTHx+Pe/fuQVFRkZdeVFSE9PR05ObmIisrC1ZWVtw1KSkpWFpa1mkaR0xMDK9sKan//WebnZ2NZcuW4fz583j27BnKy8tRWFiIzMxMABXzp7W1tXkBf+XOirU9T1RUFBQUFKpcS09Pr9KPixYtwty5c7nzvLw8aGtrv/O5CCGEENI0NZsA2sDAAAKBAHfu3OGlV+44V7mF9JveDnjFYjF8fHwwfPjwKnllZGTw8OFDODk5YfLkyfD19UWrVq1w8eJFTJw4EaWlpTW2TSwWQ1JSEvHx8ZCUlORdezNIk5WVrfILQE3at2+P9u3b47vvvsPixYthaGiIgwcPYsKECdXmryz3zfLfrosxVuf63yQWi9GtWzdux8I3VY5kfwg9Pb0aVzZxc3PD8+fPERgYCB0dHQiFQlhZWXFTR97nmcRiMQYPHsz7a0UlTU3NKmlCoZA3+k8IIYSQ5q3ZBNAqKipwcHDA5s2bMWPGjBpHg2tjYWGB1NRUGBgYVHv9+vXrKCsrQ0BAAPcS26FDh3h5pKWlUV5ezkszNzdHeXk5srOz0adPn3q36110dXUhJyeHgoICLi0zMxNPnjzhpoxcunQJEhISMDQ0hJKSEtq0aYOLFy+ib9++3D1xcXHc6Ky0tDQAVHmW6p7PwsICBw8ehJqaWo0Lj2tqauLy5ctcfWVlZYiPj4eFhcUHPXtMTAyCgoLg5OQEAHj06BHvZT9jY2NkZmbi2bNn3Jbl165dq7VMCwsLHDlyBLq6urzRbkIIIYQQoBm9RAgAQUFBKCsrg6WlJQ4ePIiUlBSkpqZi7969uHPnTpXR37ctW7YMv/zyC7y9vfHXX38hJSUFBw8exJIlSwBUjPqWlZVh06ZNuH//Pvbs2YNt27bxytDV1UV+fj7OnTuHFy9eoLCwEIaGhnBxccH48eNx9OhRPHjwANeuXYO/vz8iIiLq9Yze3t7w9PREdHQ0Hjx4gISEBLi7u6O0tJQ3r1dGRgaurq64efMmYmJiMHPmTIwaNYqbyjB//nz4+/vj4MGDSE1NxcKFC5GYmIhZs2YBqFj5QlZWlnuBLjc3l3u+pKQkpKam4sWLFygtLYWLiwtUVVXh7OyMmJgYPHjwABcuXMCsWbPw+PFjAMCsWbOwevVqhIWF4c6dO5g6dSpvVZDaZGdn4+nTp7yjcsTfwMAAe/bsQUpKCq5cuQIXFxfeXxscHBzQvn17uLq6IikpCbGxsdxLhDWNTE+bNg0vX77EmDFjcPXqVdy/fx+nT5+Gu7t7lV8eCCGEEPIf1CCbh39Gnjx5wqZPn8709PRYixYtmIKCAuvRowf76aefWEFBAZcPAAsLC6tyf2RkJLO2tmaysrJMSUmJ9ejRg+3YsYO7vm7dOqapqclkZWWZo6Mj++WXXxgAlpOTw+WZPHkyU1FRYQCYl5cXY6xiv/Zly5YxXV1d1qJFC6ahocGGDRvGkpKSGGOMBQcHM5FI9M7nO3/+PBsxYgTT1tZm0tLSTF1dnQ0YMIDFxMRweby8vJipqSkLCgpibdq0YTIyMmz48OHs5cuXXJ7y8nLm4+PD2rZty1q0aMFMTU3ZH3/8watr586dTFtbm0lISDBbW1vGGGPZ2dnMwcGBKSgoMAAsKiqKMcZYVlYWGz9+PFNVVWVCoZDp6+uzSZMmcfvJl5aWslmzZjElJSWmrKzM5s6dy8aPH8+cnZ1rfNaoqCgGoNrj0qVLjDHGbty4wSwtLZlQKGQdOnRgv/32G9PR0WHr16/nyklJSWE2NjZMWlqaGRsbs+PHjzMALDIykjHG2IMHDxgAlpCQwN2TlpbGhg0bxpSVlZmsrCwzNjZms2fPZmKx+J19lJubywBwz96QSkpKWHh4OCspKWnwssmnQX3Y9FEfNg/Uj01fQ/dhfb6/BYzVcTFe0mR4e3sjPDy8yi6CpEJsbCx69+6Ne/fuoX379g1efl5eHkQiEXJzc2uc0vK+SktLERERAScnp89q4x9Sd9SHTR/1YfNA/dj0NXQf1uf7myZ4kmYvLCwMCgoK6NChA+7du4dZs2bBxsbmowTPhBBCCGn+KIAmPNHR0bC3t0dOTg6UlZUREhKC2bNnc/OV6zK67ebmhlevXtW609+n9Pr1a3h6eiIzMxMlJSUYPHgwgoODP3q9nb1OQUIo16BlCiUZ1vQAOnufQnF5/VdMIY3vc+3DjNVfNXYTCCGkyWhWLxGSiuDVx8cHN2/eRIsWLaCvrw8PDw/eCh0fwsPDA+fOnfugMqKjoyEQCKp9iVBXVxeBgYEfVP7bxo8fj7t376KwsJDbVfHN9bcJIYQQQuqDRqCboQEDBiA4OBilpaWIiYnBd999h4KCAmzduvWDy1ZQUKh2g5HPRXl5OQQCAbfMYKWSkhJIS0vzNlR5H5XlEEIIIeS/i0agmyGhUAgNDQ1oa2vj22+/hYuLCzedYu/evbC0tISioiI0NDTw7bffIjs7u85le3t7w8zMjDsvLy/H3LlzoaysDBUVFXh6etZpd8G6WrduHbp06QJ5eXloa2tj6tSpyM/P566HhIRAWVkZJ06cgImJCYRCIR4+fAhdXV2sWLECbm5uEIlEmDRpEjIyMiAQCHjTT5KTk+Hk5AQFBQWoq6tj3LhxvHWk7ezsMH36dMydOxeqqqq1bgFOCCGEkP8GCqD/A2RlZbl1k0tKSuDr64ubN28iPDwcDx48gJub23uXHRAQgN27d2PXrl24ePEiXr58ibCwsAZqOSAhIYGNGzfi9u3bCA0Nxfnz5+Hp6cnLU1hYCD8/P/z888/466+/oKamBgD46aef0LlzZ8THx2Pp0qVVys7KyoKtrS3MzMxw/fp1bs3rUaNG8fKFhoZCSkoKsbGx2L59e5VyiouLkZeXxzsIIYQQ0nzRFI5m7urVq/j111/xxRdfAADc3d25a/r6+ti4cSN69OiB/Pz895qaERgYiEWLFmHEiBEAgG3btuHUqVN1uldLS6tKWmFhIe989uzZ3M96enrw9fXFlClTEBQUxKWXlpYiKCgIpqamvHv79esHDw8P7jwjI4N3fevWrbCwsMCqVau4tN27d0NbWxtpaWkwNDQEULFZy5o1a2p8Dj8/P/j4+NT8oIQQQghpViiAboZOnDgBBQUFlJWVobS0FM7Ozti0aRMAICEhAd7e3khMTMTLly8hFosBVGz9bWJiUq96cnNzkZWVBSsrKy5NSkoKlpaWdZrGERMTA0VFRV6anZ0d7zwqKgqrVq1CcnIy8vLyUFZWhqKiIhQUFHDbtUtLS6Nr165Vyre0tKy1/vj4eERFRVX7i0N6ejoXQL+rnEWLFmHu3LnceV5eHrS1tWu9hxBCCCFNFwXQzZC9vT22bt2KFi1aoE2bNtzi4gUFBejfvz/69++PvXv3onXr1sjMzISjoyNKSko+eTv19PSgrKzMS5OS+t9/kg8fPoSTkxMmT54MX19ftGrVChcvXsTEiRO5KSlAxRSV6rblrgywayIWizF48GD4+/tXuaapqVnncoRCIYRCYa15CCGEENJ8UADdDMnLy8PAwKBK+p07d/DixQusXr2aGyG9fv36e9cjEomgqamJy5cvo2/fvgCAsrIyxMfHw8LC4r3LrXT9+nWUlZUhICCAW1Xj0KFDH1xuJQsLCxw5cgS6urq8wJ0QQgghpDb0EuF/SLt27SAtLY1Nmzbh/v37OHbsGHx9fT+ozFmzZmH16tUICwvDnTt3MHXq1GrXd34f7du3R1lZGdfePXv2YNu2bQ1SNgBMmzYNL1++xJgxY3D16lXcv38fp0+fhru7O8rLyxusHkIIIYQ0LzTs9h/SunVrhISE4Mcff8TGjRthYWGBtWvXYsiQIe9d5rx585CVlQU3NzdISEjA3d0dw4YNQ25u7ge318zMDOvWrYO/vz8WLVqEvn37ws/PD+PHj//gsgGgTZs2iI2NxYIFC+Do6Iji4mLo6OhgwIABVdaRfh+3fRyhpKTUAC39n9LSUkREROC2tyM3NYc0LdSHhBDS9AlYQy7aSwhBXl4eRCIRcnNzP1oA7eTkRMFXE0V92PRRHzYP1I9NX0P3YX2+v2kKByGEEEIIIfVAUzgIj52dHczMzBAYGNjYTamVm5sbXr16xe2wyBjDDz/8gMOHDyMnJwcJCQkwNTWtkvbmLoofW2evU5AQyjVomUJJhjU9gM7ep1BcXnXlEfL5+9h9mLH6qwYvkxBCCB+NQDcCNzc3CASCKseAAQMau2k4evToB79YWFdRUVEYNGgQWrduDRkZGbRv3x6jR4/Gn3/++c57N2zYgJCQEO48MjISISEhOHHiBLKystC5c+dq0wghhBBCPhSNQDeSAQMGIDg4mJf2IWsJM8ZQXl7+wcuxtWrV6oPur6ugoCBMnz4d48aNw8GDB6Gnp4esrCxcu3YNc+bMQXx8fLX3lZeXQyAQQCQS8dLT09OhqakJa2vrWtMIIYQQQj4UjUA3EqFQCA0NDd7RsmVLABVbTgsEAiQmJnL5X716BYFAgOjoaABAdHQ0BAIBTp06BUtLSwiFQsTExCA9PR3Ozs5QV1eHgoICunfvjrNnz/LqDgoKQocOHSAjIwN1dXV8/fXX3DU7Ozve9tl79+6FpaUlFBUVoaGhgW+//RbZ2dnc9cp2nDt3DpaWlpCTk4O1tTVSU1NrfPbMzEzMnj0bs2fPRmhoKPr16wc9PT1YW1tj1qxZvLWpQ0JCoKysjBMnTsDExARCoRAPHz6Em5sbhg4dCqBiRH/GjBnIzMyEQCCArq5utWkAUFxcjJkzZ0JNTQ0yMjLo3bs3rl279kHPQwghhJD/FgqgmzhPT0/4+fkhJSUFXbt2RX5+PpycnHD27FkkJCTA0dERgwcPRmZmJoCKzUlmzpyJ5cuXIzU1FZGRkdwmKNUpKSmBr68vbt68ifDwcDx48ABubm5V8i1evBgBAQG4fv06pKSk4O7uXmOZR44cQWlpKTw9Pau9/vaugoWFhfDz88PPP/+Mv/76C2pqarzrGzZswPLly6GlpcWNYleXVvl5HTlyBKGhobhx4wYMDAzg6OiIly9fvvfzFBcXIy8vj3cQQgghpPmiKRyN5MSJE1BQUOClLViwAEuXLq1XOcuXL4eDgwN3rqKiAlNTU+58xYoVCAsLw7FjxzB9+nRkZmZCXl4egwYNgqKiInR0dGBubl5j+W8Gjvr6+ti4cSN69OiB/Px8XvtXrlwJW1tbAMDChQvx1VdfoaioCDIyMlXKTEtLg5KSEjQ0NLi0I0eOwNXVlTu/dOkSunTpAqBimZqgoCDec71JJBJBUVERkpKSvDLfTisoKMDWrVsREhKCgQMHAgB27tyJM2fOYNeuXZg/f/57PY+fnx98fHxq+ggJIYQQ0szQCHQjsbe3R2JiIu+YNm1avcuxtLTknRcUFMDT0xMmJiZQVlaGgoIC7ty5w41AOzg4QEdHB/r6+hg3bhz27duHwsLCGstPSEiAs7MzdHR0oKioCDs7OwDgyqvUtWtX7mdNTU0A4E31eNvbo8yOjo5ITEzEyZMnUVBQwNsJUFpamlf++0pPT0dpaSlsbGy4tBYtWqBHjx5ISUnh5a3P8yxatAi5ubnc8ejRow9uKyGEEEI+XzQC3Ujk5eVhYGBQ7bXKXfDe3OOmtLS0xnLeNH/+fJw6dQpr166FgYEBZGVl8fXXX6OkpARAxajsjRs3EB0djdOnT2PZsmXw9vbGtWvXoKyszCuroKAA/fv3R//+/bF37160bt0amZmZcHR05Mqr9OYC5pXBsVgsrrbNHTp0QG5uLp4+fcqNDisoKMDAwKDalyBlZWWrBNzvo/LzfLssxliVtPo8j1Ao/KAXQAkhhBDStNAI9GeodevWAICsrCwu7c0XCmsTExMDNzc3DBs2DF26dIGGhgYyMjJ4eaSkpPDll19izZo1SEpKQkZGBs6fP1+lrDt37uDFixdYvXo1+vTpA2Nj41pHlevq66+/RosWLeDv7//BZdWHgYEBpKWlcfHiRS6ttLQU169fR8eOHT9pWwghhBDSdNEIdCMpLi7G06dPeWlSUlJQVVWFrKwsevXqhdWrV0NXVxcvXrzAkiVL6lSugYEBjh49isGDB0MgEGDp0qW8kdMTJ07g/v376Nu3L1q2bImIiAiIxWIYGRlVKatdu3aQlpbGpk2bMHnyZNy+fbtB1ohu164dAgICMGvWLLx8+RJubm7Q09PDy5cvsXfvXgCApKTkB9fzNnl5eUyZMgXz589Hq1at0K5dO6xZswaFhYWYOHFig9dHCCGEkOaJAuhGEhkZyc2trWRkZIQ7d+4AAHbv3g13d3dYWlrCyMgIa9asQf/+/d9Z7vr16+Hu7g5ra2uoqqpiwYIFvFUhlJWVcfToUXh7e6OoqAgdOnTA/v370alTpypltW7dGiEhIfjxxx+xceNGWFhYYO3atRgyZMgHPj0wY8YMdOzYEevWrcPXX3+NvLw8qKiowMrKCpGRkdwLhA1t9erVEIvFGDduHF6/fg1LS0ucOnWKW0KwId32cYSSklKDlllaWoqIiAjc9nbkTTMhTQf1ISGENH0C9uZEW0LIB8vLy4NIJEJubu5HC6CdnJwo+GqiqA+bPurD5oH6selr6D6sz/c3jUCTRhEdHQ17e3vk5ORUeXnxU7Ozs4OZmRkCAwMbtNzOXqcgIZRr0DKFkgxregCdvU+huPzDX6wkn15d+zBj9VefsFWEEELq4z/1EuGbu9c1Vffv38eYMWPQpk0byMjIQEtLC87OzkhLS2vQet7ekRD43y59r169atC6aqKrqwuBQFDlWL169SepnxBCCCGkOjQC/ZkqLS2t8ueIkpISODg4wNjYGEePHoWmpiYeP36MiIgI5ObmNlJLP67ly5dj0qRJvDRFRcVGag0hhBBCyH9sBPpdkpOT4eTkBAUFBairq2PcuHF48eIFd/3w4cPo0qULZGVloaKigi+//BIFBQUAKkZne/ToAXl5eSgrK8PGxgYPHz7k7j1+/Di6desGGRkZ6Ovrw8fHB2VlZdx1gUCAbdu2wdnZGfLy8lixYkW17bt//z6CgoLQq1cv6OjowMbGBitXrkT37t0BABkZGRAIBDhw4ACsra0hIyODTp06ITo6mlfWhQsX0KNHDwiFQmhqamLhwoVce9zc3HDhwgVs2LCBG/XNyMiAvb09AKBly5YQCATclt6MMaxZswb6+vqQlZWFqakpDh8+zKsvIiIChoaGkJWVhb29fZWl9WqiqKgIDQ0N3lG59nV5eTkmTpwIPT09yMrKwsjICBs2bODdX1ZWhpkzZ0JZWRkqKipYsGABXF1da/1LRElJCTw9PdG2bVvIy8ujZ8+eVT4/QgghhPx3UQD9/7KysmBrawszMzNcv34dkZGRePbsGUaNGsVdHzNmDNzd3ZGSkoLo6GgMHz4cjDGUlZVh6NChsLW1RVJSEi5duoTvv/+e24Dj1KlTGDt2LGbOnInk5GRs374dISEhWLlyJa8NXl5ecHZ2xq1bt3hbaFdq3bo1JCQkcPjwYd5OfdWZP38+5s2bh4SEBFhbW2PIkCH4559/AAB///03nJyc0L17d9y8eRNbt27Frl27uKB9w4YNsLKywqRJk5CVlYWsrCxoa2vjyJEjAIDU1FRkZWVxweqSJUsQHByMrVu34q+//sKcOXMwduxYXLhwAQDw6NEjDB8+HE5OTkhMTMR3332HhQsXvm9XccRiMbS0tHDo0CEkJydj2bJl+PHHH3Ho0CEuj7+/P/bt24fg4GDExsYiLy8P4eHhtZY7YcIExMbG4sCBA0hKSsLIkSMxYMAA3L17t9r8xcXFyMvL4x2EEEIIab5oCsf/27p1KywsLLBq1Soubffu3dDW1kZaWhry8/NRVlaG4cOHQ0dHBwC4pdZevnyJ3NxcDBo0CO3btwcA3sYcK1euxMKFC+Hq6goA0NfXh6+vLzw9PeHl5cXl+/bbb6sNnCu1bdsWGzduhKenJ3x8fGBpaQl7e3u4uLhAX1+fl3f69OkYMWIE92yRkZHYtWsXPD09ERQUBG1tbWzevBkCgQDGxsZ48uQJFixYgGXLlkEkEkFaWhpycnLcToEA0KpVKwCAmpoa9+JfQUEB1q1bh/Pnz8PKyop7vosXL2L79u2wtbXF1q1boa+vj/Xr10MgEMDIyAi3bt2q00YqCxYsqLIG9okTJ2BnZ4cWLVrAx8eHS9fT00NcXBwOHTrE/eKzadMmLFq0CMOGDQMAbN68GRERETXWl56ejv379+Px48do06YNAMDDwwORkZEIDg7m/fdRyc/Pj9cOQgghhDRvFED/v/j4eERFRUFBQaHKtfT0dPTv3x9ffPEFunTpAkdHR/Tv3x9ff/01WrZsiVatWsHNzQ2Ojo5wcHDAl19+iVGjRnHrPMfHx+PatWu8Eefy8nIUFRWhsLAQcnIVKzVYWlq+s53Tpk3D+PHjERUVhStXruC3337DqlWrcOzYMTg4OHD5KoNZoGKDFktLS6SkpAAAUlJSYGVlxdu+2sbGBvn5+Xj8+DHatWtX588tOTkZRUVFvLqBimkQ5ubmXH29evXi1fdm+2ozf/58bqpIpbZt23I/b9u2DT///DMePnyIf//9FyUlJTAzMwMA5Obm4tmzZ+jRoweXX1JSEt26datxW+4bN26AMQZDQ0NeenFxMVRUVKq9Z9GiRZg7dy53npeXB21t7To9HyGEEEKaHgqg/59YLMbgwYOrHRXV1NSEpKQkzpw5g7i4OJw+fRqbNm3C4sWLceXKFejp6SE4OBgzZ85EZGQkDh48iCVLluDMmTPo1asXxGIxfHx8MHz48Cply8jIcD9Xzu19F0VFRQwZMgRDhgzBihUr4OjoiBUrVlQJYt9WGcAyxnjBbGXam3nqqjIQPXnyJC+wBQChUMgr+32oqqrCwMCg2muHDh3CnDlzEBAQACsrKygqKuKnn37ClStXePlqetbqiMViSEpKIj4+vspuiNX9cgVUPGflsxJCCCGk+aMA+v9ZWFjgyJEj0NXVhZRU9R+LQCCAjY0NbGxssGzZMujo6CAsLIwbfTQ3N4e5uTkWLVoEKysr/Prrr+jVqxcsLCyQmppaYyD4ISqnYMTFxfHSL1++jL59+wKoeJEuPj4e06dPBwCYmJjgyJEjvEA6Li4OioqKXBAsLS1dZZ61tLQ0APDSTUxMIBQKkZmZCVtb22rbaGJiUmXe8eXLl9/zif8nJiYG1tbWmDp1KpeWnp7O/SwSiaCuro6rV6+iT58+XNsTEhK4Ueq3mZubo7y8HNnZ2dw9hBBCCCFv+s8F0Lm5uUhMTOSltWrVCtOmTcPOnTsxZswYzJ8/H6qqqrh37x4OHDiAnTt34vr16zh37hz69+8PNTU1XLlyBc+fP0fHjh3x4MED7NixA0OGDEGbNm2QmpqKtLQ0jB8/HgCwbNkyDBo0CNra2hg5ciQkJCSQlJSEW7duVbvaRk0SExPh5eWFcePGwcTEBNLS0rhw4QJ2796NBQsW8PJu2bIFHTp0QMeOHbF+/Xrk5ORw86unTp2KwMBAzJgxA9OnT0dqaiq8vLwwd+5cSEhUvFeqq6uLK1euICMjAwoKCmjVqhV0dHQgEAhw4sQJODk5QVZWFoqKivDw8MCcOXMgFovRu3dv5OXlIS4uDgoKCnB1dcXkyZMREBCAuXPn4ocffkB8fDxCQkLq9MyvX7/G06dPeWlycnJQUlKCgYEBfvnlF5w6dQp6enrYs2cPrl27Bj09PS7vjBkz4OfnBwMDAxgbG2PTpk3IycmpcaTd0NAQLi4uGD9+PAICAmBubo4XL17g/Pnz6NKlC5ycnOraXYQQQghprth/iKurKwNQ5XB1dWWMMZaWlsaGDRvGlJWVmaysLDM2NmazZ89mYrGYJScnM0dHR9a6dWsmFAqZoaEh27RpE2OMsadPn7KhQ4cyTU1NJi0tzXR0dNiyZctYeXk5V3dkZCSztrZmsrKyTElJifXo0YPt2LGDuw6AhYWF1dr+58+fs5kzZ7LOnTszBQUFpqioyLp06cLWrl3L1fXgwQMGgP3666+sZ8+eTFpamnXs2JGdO3eOV1Z0dDTr3r07k5aWZhoaGmzBggWstLSUu56amsp69erFZGVlGQD24MEDxhhjy5cvZxoaGkwgEHCfm1gsZhs2bGBGRkasRYsWrHXr1szR0ZFduHCBK+/48ePMwMCACYVC1qdPH7Z7924GgOXk5NT4vDo6OtX21w8//MAYY6yoqIi5ubkxkUjElJWV2ZQpU9jChQuZqakpV0ZpaSmbPn06U1JSYi1btmQLFixgI0eOZN988w2Xx9bWls2aNYs7LykpYcuWLWO6urqsRYsWTENDgw0bNowlJSXV2j+VcnNzGQCWm5tbp/z1UVJSwsLDw1lJSUmDl00+DerDpo/6sHmgfmz6GroP6/P9LWDsAyaoks9ORkYG9PT0ap2m8F8mFovRsWNHjBo1Cr6+vh+ljry8PIhEIuTm5kJJSalByy4tLUVERAScnJyqbLRDmgbqw6aP+rB5oH5s+hq6D+vz/f2fm8JB/lsePnyI06dPw9bWFsXFxdi8eTMePHiAb7/9trGbRgghhJAmigLoT+RjjAwLBAKEhYXVuqveh3Bzc8OrV6/eufHIp/C+bZGQkEBISAg8PDxQWlqKf//9FydOnOCt0/2xdPY6BQmhXIOWKZRkWNMD6Ox9CsXl9VsxhXweaurDjNVfNWKrCCGE1AftRNgA3NzcuC2vBQIBVFRUMGDAACQlJX3ytujq6oIx1iBB+oYNG+r8sl9ji46OhkAgwKtXr7i0J0+eYODAgRAIBHj48CFevXqFrKws7kXAkJAQbkMYQgghhJC6ogC6gQwYMIDb9vrcuXOQkpLCoEGDGrtZH0QkEjXZADM9PR29e/dGu3btcPr0aSgrK0NaWhoaGhr1XuuaEEIIIeRNFEA3EKFQCA0NDWhoaMDMzAwLFizAo0eP8Pz582rzl5eXY+LEidDT04OsrCyMjIywYcOGKvl2796NTp06QSgUQlNTk1vLuTrLly+Hurp6lWX6Ks2bNw+DBw/mzgMDAyEQCHDy5EkuzcjICNu3bwdQMbL+5vQQOzs7zJw5E56enmjVqhU0NDTg7e3Nq+POnTvo3bs3ZGRkYGJigrNnz0IgEPCmXvz9998YPXo0WrZsCRUVFTg7OyMjI4P32cydOxfKyspQUVGBp6dnvTZjSUpKQu/evdGzZ0/8/vvv3E6Pb45SR0dHY8KECcjNzeX+clD5LCUlJfD09ETbtm0hLy+Pnj17Ijo6us71E0IIIaR5owD6I8jPz8e+fftgYGBQ4/bPYrEYWlpaOHToEJKTk7Fs2TL8+OOPOHToEJdn69atmDZtGr7//nvcunULx44dq3YzFsYYZs2ahV27duHixYs1Tt+ws7NDTEwMt3vghQsXoKqqigsXLgAAnj59irS0tBo3RAGA0NBQyMvL48qVK1izZg2WL1+OM2fOcM80dOhQyMnJ4cqVK9ixYwcWL17Mu7+wsBD29vZQUFDAn3/+iYsXL0JBQQEDBgxASUkJACAgIAC7d+/mnufly5cICwursU1viouLg62tLYYPH459+/bV+FautbU1AgMDoaSkxP3lwMPDAwAwYcIExMbG4sCBA0hKSsLIkSMxYMAA3L17t9qyiouLkZeXxzsIIYQQ0nzRS4QN5MSJE9xWzwUFBdDU1MSJEye4jUne1qJFC/j4+HDnenp6iIuLw6FDhzBq1CgAwIoVKzBv3jzMmjWLy9e9e3deOWVlZRg/fjyuX7+O2NhYaGlp1djGvn374vXr10hISICFhQViYmLg4eGBo0ePAgCioqKgrq4OY2PjGsvo2rUrvLy8AAAdOnTA5s2bce7cOTg4OOD06dNIT09HdHQ0NDQ0AAArV67kbTF+4MABSEhI4Oeff+amUgQHB0NZWRnR0dHo378/AgMDsWjRIowYMQIAsG3bNpw6darGNr1p2LBhGD16NLZs2VJrPmlpaYhEIggEAq6tQMXUj/379+Px48do06YNAMDDwwORkZEIDg7GqlWrqpTl5+fH60tCCCGENG80At1A7O3tkZiYiMTERFy5cgX9+/fHwIED8fDhwxrv2bZtGywtLdG6dWsoKChg586dyMzMBABkZ2fjyZMn+OKLL2qtd86cObh06RJiYmJ4wfOqVaugoKDAHZmZmRCJRDAzM0N0dDRu3boFCQkJ/PDDD7h58yZev36N6OjoWkefgYoA+k2amprIzs4GAKSmpkJbW5sXkPbo0YOXPz4+Hvfu3YOioiLXtlatWqGoqAjp6enIzc1FVlYWrKysuHukpKRgaWlZa7sqOTs7IywsDDExMXXK/7YbN26AMQZDQ0Pe53fhwgXeNuFvWrRoEXJzc7nj0aNH71U3IYQQQpoGGoFuIPLy8rzpFd26dYNIJMLOnTur3a770KFDmDNnDgICAmBlZQVFRUX89NNPuHLlCgBAVla2TvU6ODhg//79OHXqFFxcXLj0yZMncyPZALjRVDs7O0RHR0NaWhq2trZo2bIlOnXqhNjYWERHR2P27Nm11vf2lAiBQMBNCWGMvfMFPbFYjG7dumHfvn1VrrVu3brWe+ti+/btWLBgAQYOHIiTJ0++8xeC6tonKSmJ+Ph4SEpK8q5V/oXhbUKhEEKh8L3bTAghhJCmhQLoj0QgEEBCQgL//vtvtddjYmJgbW2NqVOncmlvjnAqKipCV1cX586dg729fY31DBkyBIMHD8a3334LSUlJfPPNNwCAVq1aoVWrVlXy29nZYdeuXZCSksKXX34JALC1tcWBAwfeOf/5XYyNjZGZmYlnz55BXV0dAHDt2jVeHgsLCxw8eBBqamo17vKjqamJy5cvo2/fvgAqpqnEx8fDwsLinW0QCATYvn07JCUl4eTkhJMnT8LOzq7avNLS0igvL+elmZubo7y8HNnZ2ejTp8876yOEEELIfw9N4WggxcXFePr0KZ4+fYqUlBTMmDED+fn5vFUv3mRgYIDr16/j1KlTSEtLw9KlS6sEm97e3ggICMDGjRtx9+5d3LhxA5s2bapS1rBhw7Bnzx5MmDABhw8frrWdlfOgjx8/zgWWdnZ22Lt3L1q3bg0TE5P3+wBQMRrevn17uLq6IikpCbGxsdxLhJUj0y4uLlBVVYWzszNiYmLw4MEDXLhwAbNmzcLjx48BALNmzcLq1asRFhaGO3fuYOrUqbz1nd9FIBAgKCgIEyZMwFdffYXz589Xm09XVxf5+fk4d+4cXrx4gcLCQhgaGsLFxQXjx4/H0aNH8eDBA1y7dg3+/v6IiIh478+GEEIIIc0HjUA3kMjISGhqagKoGD02NjbGb7/9VuPo5+TJk5GYmIjRo0dDIBBgzJgxmDp1Kv744w8uj6urK4qKirB+/Xp4eHhAVVUVX3/9dbXlff311xCLxRg3bhwkJCQwfPjwavOJRCKYm5sjMzOTC5b79OkDsVj8QaPPACApKYnw8HB899136N69O/T19fHTTz9h8ODBkJGRAQDIycnhzz//xIIFCzB8+HC8fv0abdu2xRdffMGNSM+bNw9ZWVlwc3ODhIQE3N3dMWzYMOTm5ta5LQKBAJs3b4akpCQGDRqEY8eOQUqK/5+7tbU1Jk+ejNGjR+Off/6Bl5cXvL29ERwczL3A+ffff0NFRQVWVlbcBix1ddvHscZR9vdVWlqKiIgI3PZ2rHGFEfJ5oz4khJCmT8Dqs8AuIfUUGxuL3r174969e2jfvn1jN+eTyMvLg0gkQm5u7kcLoJ2cnCj4aqKoD5s+6sPmgfqx6WvoPqzP9zeNQH/GMjIyoKenh4SEhFq35g4PD4eHhwcePHiAGTNmIDAw8JO18W1hYWFQUFBAhw4dcO/ePcyaNQsGBgbo1q1bvaZh1IednR3MzMwa9bmr09nrFCSEcg1aplCSYU0PoLP3KRSX046KH0PG6q8auwmEEEI+czQHugG4ublxu9lJSUmhXbt2mDJlCnJycj5J/T/88AO+/vprPHr0CL6+vg1SZkhIyHtt4/369WtMnToVxsbGcHNzQ/fu3XnrWNek8vN78+jdu/d7tJwQQggh5OOiEegGMmDAAAQHB6OsrAzJyclwd3fHq1evsH///o9ab35+PrKzs+Ho6MgtVdeYxo8fj/Hjx/PSQkJC6nRvcHAwBgwYwJ1LS0s3ZNMIIYQQQhoEjUA3EKFQCA0NDWhpaaF///4YPXo0Tp8+zcsTHByMjh07QkZGBsbGxggKCuJdv3r1KszNzSEjIwNLS0skJCTUWmd0dDQUFRUBAP369YNAIEB0dDQA4MiRI+jUqROEQiF0dXUREBDAuzcnJwfjx49Hy5YtIScnh4EDB3JbVUdHR2PChAnIzc3lRoO9vb0BACUlJfD09ETbtm0hLy+Pnj17cnVWCgkJQbt27SAnJ4dhw4bhn3/+qdNnqKysDA0NDe5o1aoV/vnnH4wZMwZaWlqQk5NDly5d3vlLSXFxMTw9PaGtrQ2hUIgOHTpg165d3PULFy6gR48eEAqF0NTUxMKFC1FWVsZdt7Ozw8yZM+Hp6YlWrVpBQ0ODe35CCCGEEAqgP4L79+8jMjKSN6F9586dWLx4MVauXImUlBSsWrUKS5cuRWhoKICK7b8HDRoEIyMjxMfHw9vbGx4eHrXWY21tjdTUVAAVAXNWVhasra0RHx+PUaNG4ZtvvsGtW7fg7e2NpUuX8kaC3dzccP36dRw7dgyXLl0CYwxOTk4oLS2FtbU1AgMDoaSkhKysLGRlZXFtmTBhAmJjY3HgwAEkJSVh5MiRGDBgABd8X7lyBe7u7pg6dSoSExNhb29f7UYydVVUVIRu3brhxIkTuH37Nr7//nuMGzeO23CmOuPHj8eBAwewceNGpKSkYNu2bdwmKH///TecnJzQvXt33Lx5E1u3bsWuXbuqtDE0NBTy8vK4cuUK1qxZg+XLl+PMmTPV1ldcXIy8vDzeQQghhJDmi6ZwNJATJ05AQUEB5eXlKCoqAgCsW7eOu+7r64uAgABueTk9PT0kJydj+/btcHV1xb59+1BeXo7du3dDTk4OnTp1wuPHjzFlypQa65SWloaamhoAcCOllfV+8cUXWLp0KQDA0NAQycnJ+Omnn+Dm5oa7d+/i2LFjiI2NhbW1NQBg37590NbWRnh4OEaOHAmRSASBQMDbljs9PR379+/H48ePuekiHh4eiIyMRHBwMFatWoUNGzbA0dERCxcu5OqOi4tDZGTkOz/DMWPG8Hb/27t3L4YOHcr7RWLGjBmIjIzEb7/9hp49e1YpIy0tDYcOHcKZM2e4jWL09fW560FBQdDW1sbmzZshEAhgbGyMJ0+eYMGCBVi2bBkkJCp+p+zatSu8vLwAAB06dMDmzZtx7tw5ODg4VKnTz88PPj4+73w+QgghhDQPFEA3EHt7e2zduhWFhYX4+eefkZaWhhkzZgAAnj9/jkePHmHixImYNGkSd09ZWRlEIhEAICUlBaamppCT+9+qDVZWVrw6OnXqhIcPHwKoWLv5zTWj35SSkgJnZ2demo2NDQIDA1FeXo6UlBRISUnxAlAVFRUYGRkhJSWlxme8ceMGGGMwNDTkpRcXF0NFRYWre9iwYbzrVlZWdQqg169fzwW9QMWOhOXl5Vi9ejUOHjyIv//+G8XFxSguLoa8vHy1ZSQmJkJSUrLGNa1TUlJgZWXF23LcxsYG+fn5ePz4Mdq1awegIoB+k6amJrKzs6stc9GiRZg7dy53npeXB21t7Xc+LyGEEEKaJgqgG4i8vDwMDAwAABs3boS9vT18fHzg6+sLsVgMoGIax9ujppUjrnVZjjsiIgKlpaUAAFlZ2RrzMcZ4AeLb5ddUV3X3vUksFkNSUhLx8fG8kWIA3BSJD1lWXENDg/sMK61Zswbr169HYGAgunTpAnl5ecyePRslJSXVllHb51LZvpo+mzfT315PUiAQcP34NqFQCKFQWGu9hBBCCGk+KID+SLy8vDBw4EBMmTIFbdq0Qdu2bXH//n24uLhUm9/ExAR79uzBv//+ywWBly9f5uXR0dGpU90mJia4ePEiLy0uLg6GhoaQlJSEiYkJysrKcOXKFW4Kxz///IO0tDR07NgRQMX0kPLycl4Z5ubmKC8vR3Z2Nvr06VNj3W+3++3z+oiJiYGzszPGjh0LoCKIv3v3LtfOt3Xp0gVisRgXLlzgjWa/2b4jR47wAum4uDgoKiqibdu2791OQgghhPx30EuEH4mdnR06deqEVatWAQC8vb3h5+eHDRs2IC0tDbdu3UJwcDA3T/rbb7+FhIQEJk6ciOTkZERERGDt2rXvVfe8efNw7tw5+Pr6Ii0tDaGhodi8eTM3l7hDhw5wdnbGpEmTcPHiRdy8eRNjx45F27Ztuakfurq6yM/Px7lz5/DixQsUFhbC0NAQLi4uGD9+PI4ePYoHDx7g2rVr8Pf3R0REBABg5syZiIyMxJo1a5CWlobNmzfXafpGTQwMDHDmzBnExcUhJSUFP/zwA54+fVpjfl1dXbi6usLd3R3h4eF48OABoqOjcejQIQDA1KlT8ejRI8yYMQN37tzB77//Di8vL8ydO5eb/0wIIYQQUitGPpirqytzdnaukr5v3z4mLS3NMjMzuXMzMzMmLS3NWrZsyfr27cuOHj3K5b906RIzNTVl0tLSzMzMjB05coQBYAkJCTXWnZOTwwCwqKgoXvrhw4eZiYkJa9GiBWvXrh376aefeNdfvnzJxo0bx0QiEZOVlWWOjo4sLS2Nl2fy5MlMRUWFAWBeXl6MMcZKSkrYsmXLmK6uLmvRogXT0NBgw4YNY0lJSdx9u3btYlpaWkxWVpYNHjyYrV27lolEolo/QwAsLCysSvo///zDnJ2dmYKCAlNTU2NLlixh48eP533etra2bNasWdz5v//+y+bMmcM0NTWZtLQ0MzAwYLt37+auR0dHs+7duzNpaWmmoaHBFixYwEpLS2ssjzHGnJ2dmaura63PUCk3N5cBYLm5uXXKXx8lJSUsPDyclZSUNHjZ5NOgPmz6qA+bB+rHpq+h+7A+398Cxj5g0iohpIq8vDyIRCLk5uZCSUmpQcsuLS1FREQEnJycqszTJk0D9WHTR33YPFA/Nn0N3Yf1+f6mv1kTQgghhBBSD/QS4ScmEAgQFhaGoUOHVns9Ojoa9vb2yMnJgbKy8idtW01CQkIwe/ZsvHr1CkDFfO7w8HAkJia+d5kZGRnQ09NDQkICzMzMGqSd78vNzQ2vXr1CeHh4g5bb2esUJIRy785YD0JJhjU9gM7ep1BcXvOKKeT9Zaz+qrGbQAgh5DNHI9DvYdu2bVBUVORt/5yfn48WLVpUWZ0iJiYGAoEAaWlpdSrb2toaWVlZ3PrQISEhDRZIe3t7v1ewOnr06Dq3vyHZ2dlxW4m/eUyePPmTt4UQQgghpBKNQL8He3t75Ofn4/r16+jVqxeAikBZQ0MD165dQ2FhIbchSnR0NNq0aVNl85GaSEtL83b/+xzIysq+c33lj2XSpElYvnw5L+3NzWYIIYQQQj41GoF+D0ZGRmjTpg2io6O5tOjoaDg7O6N9+/aIi4vjpdvb2/Puf/HiBYYNGwY5OTl06NABx44d4+UXCAR49eoVoqOjMWHCBOTm5nKjr97e3gCAkpISeHp6om3btpCXl0fPnj157XlbSEgIfHx8cPPmTa6skJAQABVbf1duUqKtrY2pU6ciPz+fd++7RsGDg4PRsWNHyMjIwNjYGEFBQbzrV69ehbm5OWRkZGBpaYmEhIRay6skJycHDQ0N3vHmxP4FCxbA0NAQcnJy0NfXx9KlS7nNZiqtWLECampqUFRUxHfffYeFCxfWOhLPGMOaNWugr68PWVlZmJqa4vDhw3VqLyGEEEKaPwqg35OdnR2ioqK486ioKNjZ2cHW1pZLLykpwaVLl6oE0D4+Phg1ahSSkpLg5OQEFxcXvHz5skod1tbWCAwMhJKSErKyspCVlcWt5TxhwgTExsbiwIEDSEpKwsiRIzFgwADcvXu32vaOHj0a8+bNQ6dOnbiyRo8eDQCQkJDAxo0bcfv2bYSGhuL8+fPw9PSs82exc+dOLF68GCtXrkRKSgpWrVqFpUuXIjQ0FABQUFCAQYMGwcjICPHx8fD29uae40MpKioiJCQEycnJ2LBhA3bu3In169dz1/ft24eVK1fC398f8fHxaNeuHbZu3VprmUuWLEFwcDC2bt2Kv/76C3PmzMHYsWNx4cKFavMXFxcjLy+PdxBCCCGk+aIA+j3Z2dkhNjYWZWVleP36NRISEtC3b1/Y2tpyI8GXL1/Gv//+WyWAdnNzw5gxY2BgYIBVq1ahoKAAV69erVKHtLQ0RCIRBAIBN/qqoKCA9PR07N+/H7/99hv69OmD9u3bw8PDA71790ZwcHC17ZWVlYWCggKkpKS4siqnZcyePRv29vbQ09NDv3794Ovry208Uhe+vr4ICAjA8OHDoaenh+HDh2POnDnYvn07gIogtry8HLt370anTp0waNAgzJ8/v05lBwUFQUFBgXdUBuZARbBrbW0NXV1dDB48GPPmzeO1fdOmTZg4cSImTJgAQ0NDLFu2DF26dKmxvoKCAqxbtw67d++Go6Mj9PX14ebmhrFjx3LP8zY/Pz+IRCLu0NbWrtOzEUIIIaRpojnQ78ne3h4FBQW4du0acnJyYGhoCDU1Ndja2mLcuHEoKChAdHQ02rVrB319fd69Xbt25X6Wl5eHoqIisrOz61z3jRs3wBirMq+6uLgYKioqAAAFBQUufezYsdi2bVuN5UVFRWHVqlVITk5GXl4eysrKUFRUhIKCAsjLy9falufPn+PRo0eYOHEiJk2axKWXlZVxL0KmpKTA1NSUN3fZysqqTs/q4uKCxYsX89LU1NS4nw8fPozAwEDcu3cP+fn5KCsr403xSE1NxdSpU3n39+jRA+fPn6+2vuTkZBQVFcHBwYGXXlJSAnNz82rvWbRoEebOncud5+XlURBNCCGENGMUQL8nAwMDaGlpISoqCjk5ObC1tQUAaGhoQE9PD7GxsYiKikK/fv2q3Pv2Yt8CgQBisbjOdYvFYkhKSiI+Ph6SkpK8a5WB85tLzNW2GPjDhw/h5OSEyZMnw9fXF61atcLFixcxceLEKnOJa2oLUDGNo2fPnrxrlW37kL16RCIRDAwMqr12+fJlfPPNN/Dx8YGjoyNEIhEOHDiAgIAAXj6BgL/cW23tqXyekydPom3btrxrQqGw2nuEQmGN1wghhBDS/FAA/QHs7e0RHR2NnJwc3pQEW1tbnDp1CpcvX8aECRM+qA5paWmUl5fz0szNzVFeXo7s7Owqy+ZVqi7orK6s69evo6ysDAEBAZCQqJjRU5/pG+rq6mjbti3u378PFxeXavOYmJhgz549+Pfff7lpI5cvX65zHTWJjY2Fjo4Ob4T64cOHvDxGRka4evUqxo0bx6Vdv369xjJNTEwgFAqRmZnJ/VJECCGEEPImCqA/gL29PaZNm4bS0lJesGVra4spU6agqKioyvzn+tLV1UV+fj7OnTvHTYMwNDSEi4sLxo8fj4CAAJibm+PFixc4f/48unTpAicnpxrLevDgARITE6GlpQVFRUW0b98eZWVl2LRpEwYPHozY2Nhap3tUx9vbGzNnzoSSkhIGDhyI4uJiXL9+HTk5OZg7dy6+/fZbLF68GBMnTsSSJUuQkZGBtWvX1qnswsJCPH36lJcmFArRsmVLGBgYIDMzEwcOHED37t1x8uRJhIWF8fLOmDEDkyZNgqWlJaytrXHw4EEkJSVVmVZTSVFRER4eHpgzZw7EYjF69+6NvLw8xMXFQUFBAa6urvX6bAghhBDSDDHy3h48eMAAMGNjY176o0ePGADWvn37KvcAYGFhYbw0kUjEgoODGWOMRUVFMQAsJyeHuz558mSmoqLCADAvLy/GGGMlJSVs2bJlTFdXl7Vo0YJpaGiwYcOGsaSkpBrbW1RUxEaMGMGUlZUZAK7OdevWMU1NTSYrK8scHR3ZL7/8wmtDcHAwE4lEXDleXl7M1NSUV/a+ffuYmZkZk5aWZi1btmR9+/ZlR48e5a5funSJmZqaMmlpaWZmZsaOHDnCALCEhIQa22tra8sAVDkcHR25PPPnz2cqKipMQUGBjR49mq1fv57XVsYYW758OVNVVWUKCgrM3d2dzZw5k/Xq1Yu77urqypydnblzsVjMNmzYwIyMjFiLFi1Y69atmaOjI7tw4UKNbX1Tbm4uA8Byc3PrlL8+SkpKWHh4OCspKWnwssmnQX3Y9FEfNg/Uj01fQ/dhfb6/BYx9wARVQpogBwcHaGhoYM+ePR+l/Ly8PIhEIuTm5tY6//x9lJaWIiIiAk5OTlXm0pOmgfqw6aM+bB6oH5u+hu7D+nx/0xSOz5C3tzfCw8N5LwLWha6uLmbPno3Zs2d/lHY1pMoNZnJychpsq/LqFBYWYtu2bXB0dISkpCT279+Ps2fP4syZMzXe4+bmhlevXiE8PPyD6u7sdQoSwobdNVEoybCmB9DZ+xSKywXvvqEJyVj9VWM3gRBCCKkTWgf6/7m5uXE79ElJSaFdu3aYMmUKcnJyGrtp/1m6uroIDAysku7t7V3rToJvEggEiIiIQJ8+fdCtWzccP34cR44cwZdfftmwjSWEEELIfwaNQL9hwIABCA4ORllZGZKTk+Hu7o5Xr15h//79jd008p5kZWVx9uzZxm4GIYQQQpoRGoF+g1AohIaGBrS0tNC/f3+MHj0ap0+f5q6LxWIsX74cWlpaEAqFMDMzQ2RkJHc9OjoaAoEAr1694tISExMhEAiQkZHBpe3cuRPa2tqQk5PDsGHDsG7dumqnMezZswe6uroQiUT45ptv8Pr163o9T25uLr7//nuoqalBSUkJ/fr1w82bN3l5VqxYATU1NSgqKuK7777DwoULeaO7ZWVlmDlzJpSVlaGiooIFCxbA1dUVQ4cO5fIwxrBmzRro6+tDVlYWpqamOHz4MK+eiIgIGBoaQlZWFvb29rzP40Ndu3YNDg4OUFVVhUgkgq2tLW7cuMFdnzdvHgYPHsydBwYGQiAQ4OTJk1yakZFRjTsNxsfHQ01NDStXrmywNhNCCCGk6aIAugb3799HZGQkb1L6hg0bEBAQgLVr1yIpKQmOjo4YMmQI7t69W+dyY2NjMXnyZMyaNQuJiYlwcHCoNjBLT09HeHg4Tpw4gRMnTuDChQtYvXp1nethjOGrr77C06dPERERgfj4eFhYWOCLL77Ay5cvAVRssb1y5Ur4+/sjPj4e7dq1w9atW3nl+Pv7Y9++fQgODkZsbCzy8vKqzA1esmQJgoODsXXrVvz111+YM2cOxo4diwsXLgAAHj16hOHDh8PJyQmJiYlcoN5QXr9+DVdXV8TExODy5cvo0KEDnJycuF847OzsEBMTw22ScuHCBaiqqnLte/r0KdLS0qpd9zk6OhpffPEFfHx8quyIWKm4uBh5eXm8gxBCCCHNF03heMOJEyegoKCA8vJyFBUVAQDWrVvHXV+7di0WLFiAb775BkBFcBkVFYXAwEBs2bKlTnVs2rQJAwcOhIeHBwDA0NAQcXFxOHHiBC+fWCxGSEgIFBUVAQDjxo3DuXPn6jwKGhUVhVu3biE7O5vbJW/t2rUIDw/H4cOH8f3332PTpk2YOHEit9nLsmXLcPr0aeTn5/Pau2jRIgwbNgwAsHnzZkRERHDXCwoKsG7dOpw/f57bnltfXx8XL17E9u3bYWtri61bt0JfXx/r16+HQCCAkZERbt26BX9//3c+x4IFC7BkyRJeWklJCUxMTLjzt3d73L59O1q2bIkLFy5g0KBB6Nu3L16/fo2EhARYWFggJiYGHh4eOHr0KPdZqaurw9jYmFfO77//jnHjxmH79u0YM2ZMjW308/ODj4/PO5+FEEIIIc0DjUC/wd7eHomJibhy5QpmzJgBR0dHzJgxA0DF0iZPnjyBjY0N7x4bGxukpKTUuY7U1FT06NGDl/b2OVDxAl1l8AwAmpqayM7OBlAxcqygoMAdMTExVe6Pj49Hfn4+VFRUeHkfPHiA9PT0OrUlNzcXz54946VJSkqiW7du3HlycjKKiorg4ODAq+eXX37h6klJSUGvXr14W2pXBtvvMn/+fCQmJvKOyZMn8/JkZ2dj8uTJMDQ0hEgkgkgkQn5+PjIzMwFUbAduZmaG6Oho3Lp1CxISEvjhhx9w8+ZNvH79GtHR0VVGn69cuYIRI0YgNDS01uAZABYtWoTc3FzuePToUZ2ejRBCCCFNE41Av0FeXp7bAnvjxo2wt7eHj48PfH19uTxvBoFAxVSJyrTKrbDfXFq7tLS0xvxvpr3t7fUMBQIBNwVhyJAh6NmzJ3etbdu2Ve4Xi8XQ1NREdHR0lWtvzreuS1tqy1PZppMnT1ZpR+XI94csNa6qqlplW/JWrVrxzt3c3PD8+XMEBgZCR0cHQqEQVlZWKCkp4fLY2dkhOjoa0tLSsLW1RcuWLdGpUyfExsYiOjq6ytJ/7du3h4qKCnbv3o2vvvoK0tLSNbZRKBRyz0oIIYSQ5o9GoGvh5eWFtWvX4smTJ1BSUkKbNm1w8eJFXp64uDh07NgRANC6dWsAQFZWFnf97bWcjY2NcfXqVV7a9evX69UuRUVFGBgYcIesrGyVPBYWFnj69CmkpKR4eQ0MDKCqqgqg4sW52toiEomgrq7Oy1NeXo6EhATu3MTEBEKhEJmZmVXq0dbW5vJcvnyZV8/b5x8iJiYGM2fOhJOTEzp16gShUIgXL17w8lTOgz5//jzs7OwAVGy5fuDAgWrnP6uqquL8+fNIT0/H6NGjq/wiRAghhJD/Lgqga2FnZ4dOnTph1apVACqmE/j7++PgwYNITU3FwoULkZiYiFmzZgEAFzR6e3sjLS0NJ0+eREBAAK/MGTNmICIiAuvWrcPdu3exfft2/PHHH1VGeT/Ul19+CSsrKwwdOhSnTp1CRkYG4uLisGTJEi5InjFjBnbt2oXQ0FDcvXsXK1asQFJSEq8tM2bMgJ+fH37//XekpqZi1qxZyMnJ4fIoKirCw8MDc+bMQWhoKNLT05GQkIAtW7YgNDQUADB58mSkp6dj7ty5SE1Nxa+//oqQkJAGe1YDAwPs2bMHKSkpuHLlClxcXKr8UlE5D/r48eNcAG1nZ4e9e/eidevWvDnVldTU1HD+/HncuXMHY8aMQVlZWYO1mRBCCCFNF03heIe5c+diwoQJWLBgAWbOnIm8vDzMmzcP2dnZMDExwbFjx9ChQwcAFdMu9u/fjylTpsDU1BTdu3fHihUrMHLkSK48GxsbbNu2DT4+PliyZAkcHR0xZ84cbN68uUHbXbmByOLFi+Hu7o7nz59DQ0MDffv2hbq6OgDAxcUF9+/fh4eHB4qKijBq1Ci4ubnxRpwXLFiAp0+fYvz48ZCUlMT333/P7epXydfXF2pqavDz88P9+/ehrKwMCwsL/PjjjwCAdu3a4ciRI5gzZw6CgoLQo0cPrFq1Cu7u7g3yrLt378b3338Pc3NztGvXDqtWreJe0qwkEolgbm6OzMxMLlju06cPxGJxtatvVNLQ0OBGrV1cXPDrr7/ynr02t30cP9pW3re9HWnrWUIIIaSRCNiHTFAlDWLSpEm4c+dOtS8DfmoODg7Q0NDAnj17qr0uFovRsWNHjBo1ijc3nPxPXl4eRCIRcnNzP1oA7eTkRAF0E0V92PRRHzYP1I9NX0P3YX2+v2kEuhGsXbsWDg4OkJeXxx9//IHQ0FAEBQV98nYUFhZi27Zt3Ijy/v37cfbsWZw5c4bL8/DhQ5w+fRq2trYoLi7G5s2b8eDBA3z77befvL2EEEIIIZ8DCqAbwdWrV7FmzRq8fv0a+vr62LhxI7777rtP3o7KaR4rVqxAcXExjIyMcOTIEXz55ZdcHgkJCYSEhMDDwwOMMXTu3Blnz57lXpz8HOjq6mL27NlVVtJobJ29TkFCKNegZQolGdZUXfWQEEIIIZ8QBdCN4NChQx90v5ubG169elVlR8D6kpWVxdmzZ2vNo62tjdjY2A+q510yMjKgp6dXJd3FxQV79+79qHUTQgghhNQXBdDkkykvL4dAIODWy37b2bNn0alTJ+68uuX5CCGEEEIaGy1j1wytW7cOXbp0gby8PLS1tTF16lTe9twhISFQVlbGqVOn0LFjRygoKGDAgAG89avd3NwwdOhQrF27FpqamlBRUcG0adN46yGXlJTA09MTbdu2hby8PHr27MnbuKWynhMnTnDrRT98+LDGdquoqEBDQ4M7RCIR0tPT4ezsDHV1dSgoKKB79+7vHDV/9eoVvv/+e6irq0NGRgadO3fmbZV+5MgRbr1oXV3dKksN6urqcquEKCoqol27dtixY8c7P3dCCCGE/DdQAN0MSUhIYOPGjbh9+zZCQ0Nx/vx5eHp68vIUFhZi7dq12LNnD/78809kZmZWWfotKioK6enpiIqKQmhoKEJCQnjrN0+YMAGxsbE4cOAAkpKSMHLkSAwYMAB3797l1ePn54eff/4Zf/31F9TU1Or1LPn5+XBycsLZs2eRkJAAR0dHDB48mNum+21isRgDBw5EXFwc9u7di+TkZKxevZpbei4+Ph6jRo3CN998g1u3bsHb2xtLly6tsi51QEAALC0tkZCQgKlTp2LKlCm4c+dOtXUWFxcjLy+PdxBCCCGk+aIpHM3Qmy/T6enpwdfXF1OmTOGt9FFaWopt27ahffv2AIDp06dj+fLlvHJatmyJzZs3Q1JSEsbGxvjqq69w7tw5TJo0Cenp6di/fz8eP36MNm3aAAA8PDwQGRmJ4OBgbvOZ0tJSBAUFwdTU9J3ttra25k3viImJgbm5Oe/eFStWICwsDMeOHcP06dOrlHH27FlcvXoVKSkpMDQ0BADo6+tz19etW4cvvvgCS5cuBQAYGhoiOTkZP/30E9zc3Lh8Tk5OmDp1KoCKtbDXr1+P6OhoGBsbV6nTz88PPj4+73w+QgghhDQPFEA3Q1FRUVi1ahWSk5ORl5eHsrIyFBUVoaCgAPLy8gAAOTk5LngGAE1NTWRnZ/PK6dSpE2/TEE1NTdy6dQsAcOPGDTDGuCC1UnFxMVRUVLhzaWlpdO3atU7tPnjwIG91D21tbRQUFMDHxwcnTpzAkydPUFZWhn///bfGEejExERoaWlVaVellJQUODs789JsbGwQGBiI8vJy7nnfbLNAIICGhkaVz6fSokWLMHfuXO48Ly+P28acEEIIIc0PBdDNzMOHD+Hk5ITJkyfD19cXrVq1wsWLFzFx4kTe/OW3FxwXCAR4e0+d6vKIxWIAFVMlJCUlER8fX2VnPgUFBe5nWVnZOm9Trq2tDQMDA17anDlzcOrUKaxduxYGBgaQlZXF119/jZKSkmrLeNeLh4yxKu2pbi+h2p79bUKhEEKhsNZ6CSGEENJ8UADdzFy/fh1lZWUICAjgpkN86LJ51TE3N0d5eTmys7PRp0+fBi+/UkxMDNzc3DBs2DAAFXOiMzIyaszftWtXPH78GGlpadWOQpuYmODixYu8tLi4OBgaGtZ5i25CCCGE/LdRAN1E5ebmIjExkZfWqlUrtG/fHmVlZdi0aRMGDx6M2NhYbNu2rcHrNzQ0hIuLC8aPH4+AgACYm5vjxYsXOH/+PLp06QInJ6cGqcfAwABHjx7F4MGDIRAIsHTp0hpHggHA1tYWffv2xYgRI7Bu3ToYGBjgzp07EAgEGDBgAObNm4fu3bvD19cXo0ePxqVLl7B58+ZG2QmSEEIIIU0TBdBNVHR0NMzNzXlprq6uCAkJwbp16+Dv749Fixahb9++8PPzw/jx4xu8DcHBwVixYgXmzZuHv//+GyoqKrCysmqw4BkA1q9fD3d3d1hbW0NVVRULFix45yoXR44cgYeHB8aMGYOCggIYGBhg9erVAAALCwscOnQIy5Ytg6+vLzQ1NbF8+XLeC4QN5baPI5SUlBq0zNLSUkRERDRomYQQQgipHwGrbgIoIeS95eXlQSQSITc396MF0E5OTlXmaZOmgfqw6aM+bB6oH5u+hu7D+nx/0wg0+c+r3Eo8ISEBZmZmDVZuZ69TkBDKNVh5ACCUZFjTo0GLJIQQQkg90UYqzUR2djZ++OEHtGvXDkKhEBoaGnB0dMSlS5e4PAKBAOHh4Y3XyHqKjo6GQCCo9nj69GljN48QQggh/1E0At1MjBgxAqWlpQgNDYW+vj6ePXuGc+fO4eXLl43dtA+Wmppa5U8p9d3RkBBCCCGkodAIdDPw6tUrXLx4Ef7+/rC3t4eOjg569OiBRYsW4auvvgIA6OrqAgCGDRsGgUDAnQPA8ePH0a1bN8jIyEBfXx8+Pj4oKyvjrgsEAmzduhUDBw6ErKws9PT08Ntvv3HXMzIyIBAIcODAAVhbW0NGRgadOnVCdHQ0r53JyclwcnKCgoIC1NXVMW7cOLx48eKdz6empgYNDQ3eUblE37Vr1+Dg4ABVVVWIRCLY2trixo0bvPvv3LmD3r17Q0ZGBiYmJjh79uw7R+Pft62EEEIIaf4ogG4GFBQUoKCggPDwcBQXF1eb59q1awAqVs7Iysrizk+dOoWxY8di5syZSE5Oxvbt2xESEoKVK1fy7l+6dClGjBiBmzdvYuzYsRgzZgxSUlJ4eebPn4958+YhISEB1tbWGDJkCP755x8AQFZWFmxtbWFmZobr168jMjISz549w6hRoz7o2V+/fg1XV1fExMTg8uXL6NChA5ycnPD69WsAFRu+DB06FHJycrhy5Qp27NiBxYsX11pmfdtaXFyMvLw83kEIIYSQ5osC6GZASkoKISEhCA0NhbKyMmxsbPDjjz8iKSmJy9O6dWsAgLKyMjQ0NLjzlStXYuHChXB1dYW+vj4cHBzg6+uL7du38+oYOXIkvvvuOxgaGsLX1xeWlpbYtGkTL8/06dMxYsQIdOzYEVu3boVIJMKuXbsAAFu3boWFhQVWrVoFY2NjmJubY/fu3YiKikJaWlqtz6elpcX9kqCgoAAjIyPuWr9+/TB27Fh07NgRHTt2xPbt21FYWIgLFy4AAE6fPo309HT88ssvMDU1Re/evav8cvC2+rbVz88PIpGIO2gbb0IIIaR5oznQzcSIESPw1VdfISYmBpcuXUJkZCTWrFmDn3/+udY1juPj43Ht2jVeUFleXo6ioiIUFhZCTq5iFQkrKyvefVZWVlU2cnkzj5SUFCwtLblR6vj4eERFRfG2+a6Unp5e7a6BlWJiYqCoqMgru1J2djaWLVuG8+fP49mzZygvL0dhYSEyMzMBVMyf1tbWhoaGBndPjx61L2NR37YuWrQIc+fO5c7z8vIoiCaEEEKaMQqgmxEZGRk4ODjAwcEBy5Ytw3fffQcvL69aA2ixWAwfHx8MHz682vJqIxAI3tmmyjxisRiDBw+Gv79/lTyampq1lqGnpwdlZeVqr7m5ueH58+cIDAyEjo4OhEIhrKysUFJSAgBgjNWpnW+qb1uFQiGEQmG96iCEEEJI00UBdDNmYmLCe1GuRYsWKC8v5+WxsLBAamoqDAwMai3r8uXLvN0ML1++XGUnxMuXL6Nv374AgLKyMsTHx2P69OlcPUeOHIGuri5vBPlDxcTEICgoiNv98NGjR7yX/YyNjZGZmYlnz55BXV0dwP/mg9fkY7WVEEIIIc0DzYFuBv755x/069cPe/fuRVJSEh48eIDffvsNa9asgbOzM5dPV1cX586dw9OnT5GTkwMAWLZsGX755Rd4e3vjr7/+QkpKCg4ePIglS5bw6vjtt9+we/dupKWlwcvLC1evXuWC40pbtmxBWFgY7ty5g2nTpiEnJwfu7u4AgGnTpuHly5cYM2YMrl69ivv37+P06dNwd3evEtS/LTs7G0+fPuUdpaWlAAADAwPs2bMHKSkpuHLlClxcXCArK8vd6+DggPbt28PV1RVJSUmIjY3lXiKsaWT6Q9pKCCGEkP8ARpq8oqIitnDhQmZhYcFEIhGTk5NjRkZGbMmSJaywsJDLd+zYMWZgYMCkpKSYjo4Olx4ZGcmsra2ZrKwsU1JSYj169GA7duzgrgNgW7ZsYQ4ODkwoFDIdHR22f/9+7vqDBw8YAPbrr7+ynj17MmlpadaxY0d27tw5XjvT0tLYsGHDmLKyMpOVlWXGxsZs9uzZTCwWV/tcUVFRDEC1x6VLlxhjjN24cYNZWloyoVDIOnTowH777Temo6PD1q9fz5WTkpLCbGxsmLS0NDM2NmbHjx9nAFhkZCSv/QkJCe/d1jfl5uYyACw3N/edeeurpKSEhYeHs5KSkgYvm3wa1IdNH/Vh80D92PQ1dB/W5/tbwBhjjRO6k6ZCIBAgLCwMQ4cOrfb6x9oK+2OJjY1F7969ce/ePbRv377By8/Ly4NIJEJubm6VDWA+VGlpKSIiIuDk5IQWLVo0aNnk06A+bPqoD5sH6semr6H7sD7f3zTBkzR7YWFhUFBQQIcOHXDv3j3MmjULNjY2HyV4JoQQQkjzRwE0afZev34NT09PPHr0CKqqqvjyyy8REBDQ2M0ihBBCSBNFATR5p3fN8tHV1X1nnsY0fvx43goihBBCCCEfglbhIIQQQgghpB4ogCaEEEIIIaQeKIAmhBBCCCGkHiiAJoQQQgghpB4ogCaEEEIIIaQeKIAmhBBCCCGkHiiAJoQQQgghpB4ogCaEEEIIIaQeKIAmhBBCCCGkHiiAJoQQQgghpB4ogCaEEEIIIaQepBq7AYQ0N4wxAEBeXl6Dl11aWorCwkLk5eWhRYsWDV4++fioD5s+6sPmgfqx6WvoPqz83q78Hq8NBdCENLDXr18DALS1tRu5JYQQQgipr9evX0MkEtWaR8DqEmYTQupMLBbjyZMnUFRUhEAg4NK7d++Oa9euVXtPTdfeTs/Ly4O2tjYePXoEJSWlhm98PdT2PJ+yvPrcV5e878pT176qKZ368MPuoz7koz6s27Xq0qgfP+y+D+3Hz/E7kTGG169fo02bNpCQqH2WM41AE9LAJCQkoKWlVSVdUlKyxv/Ba7pWU7qSklKj/4Nf2/N8yvLqc19d8r4rT337ivqwYe+jPuSjPqzbtdryUz++330f2o+f63fiu0aeK9FLhIR8ItOmTav3tdruaWwN3bb3La8+99Ul77vy1LevqA8b9j7qQz7qw7pd+5z7EPhv9mNT/06kKRyENCF5eXkQiUTIzc1t9BET8n6oD5s+6sPmgfqx6WvMPqQRaEKaEKFQCC8vLwiFwsZuCnlP1IdNH/Vh80D92PQ1Zh/SCDQhhBBCCCH1QCPQhBBCCCGE1AMF0IQQQgghhNQDBdCEEEIIIYTUAwXQhBBCCCGE1AMF0IQQQgghhNQDBdCENBMnTpyAkZEROnTogJ9//rmxm0Pe07Bhw9CyZUt8/fXXjd0U8h4ePXoEOzs7mJiYoGvXrvjtt98au0mknl6/fo3u3bvDzMwMXbp0wc6dOxu7SeQ9FRYWQkdHBx4eHg1eNi1jR0gzUFZWBhMTE0RFRUFJSQkWFha4cuUKWrVq1dhNI/UUFRWF/Px8hIaG4vDhw43dHFJPWVlZePbsGczMzJCdnQ0LCwukpqZCXl6+sZtG6qi8vBzFxcWQk5NDYWEhOnfujGvXrkFFRaWxm0bqafHixbh79y7atWuHtWvXNmjZNAJNSDNw9epVdOrUCW3btoWioiKcnJxw6tSpxm4WeQ/29vZQVFRs7GaQ96SpqQkzMzMAgJqaGlq1aoWXL182bqNIvUhKSkJOTg4AUFRUhPLyctBYY9Nz9+5d3LlzB05OTh+lfAqgCfkM/Pnnnxg8eDDatGkDgUCA8PDwKnmCgoKgp6cHGRkZdOvWDTExMdy1J0+eoG3btty5lpYW/v7770/RdPKGD+1H0vgasg+vX78OsVgMbW3tj9xq8qaG6MNXr17B1NQUWlpa8PT0hKqq6idqPQEapg89PDzg5+f30dpIATQhn4GCggKYmppi8+bN1V4/ePAgZs+ejcWLFyMhIQF9+vTBwIEDkZmZCQDVjo4IBIKP2mZS1Yf2I2l8DdWH//zzD8aPH48dO3Z8imaTNzREHyorK+PmzZt48OABfv31Vzx79uxTNZ/gw/vw999/h6GhIQwNDT9eIxkh5LMCgIWFhfHSevTowSZPnsxLMzY2ZgsXLmSMMRYbG8uGDh3KXZs5cybbt2/fR28rqdn79GOlqKgoNmLEiI/dRPIO79uHRUVFrE+fPuyXX375FM0ktfiQ/w8rTZ48mR06dOhjNZG8w/v04cKFC5mWlhbT0dFhKioqTElJifn4+DRou2gEmpDPXElJCeLj49G/f39eev/+/REXFwcA6NGjB27fvo2///4br1+/RkREBBwdHRujuaQGdelH8nmrSx8yxuDm5oZ+/fph3LhxjdFMUou69OGzZ8+Ql5cHAMjLy8Off/4JIyOjT95WUr269KGfnx8ePXqEjIwMrF27FpMmTcKyZcsatB1SDVoaIaTBvXjxAuXl5VBXV+elq6ur4+nTpwAAKSkpBAQEwN7eHmKxGJ6envTG+GemLv0IAI6Ojrhx4wYKCgqgpaWFsLAwdO/e/VM3l1SjLn0YGxuLgwcPomvXrty8zT179qBLly6furmkGnXpw8ePH2PixIlgjIExhunTp6Nr166N0VxSjbr+W/qxUQBNSBPx9pxmxhgvbciQIRgyZMinbhapp3f1I62e8vmrrQ979+4NsVjcGM0i9VBbH3br1g2JiYmN0CpSH+/6t7SSm5vbR6mfpnAQ8plTVVWFpKRkld+ss7Ozq/wGTj5f1I9NH/Vh00d92PR9Ln1IATQhnzlpaWl069YNZ86c4aWfOXMG1tbWjdQqUl/Uj00f9WHTR33Y9H0ufUhTOAj5DOTn5+PevXvc+YMHD5CYmIhWrVqhXbt2mDt3LsaNGwdLS0tYWVlhx44dyMzMxOTJkxux1eRt1I9NH/Vh00d92PQ1iT5s0DU9CCHvJSoqigGocri6unJ5tmzZwnR0dJi0tDSzsLBgFy5caLwGk2pRPzZ91IdNH/Vh09cU+lDAGO1PSQghhBBCSF3RHGhCCCGEEELqgQJoQgghhBBC6oECaEIIIYQQQuqBAmhCCCGEEELqgQJoQgghhBBC6oECaEIIIYQQQuqBAmhCCCGEEELqgQJoQgghhBBC6oECaEIIIc1GRkYGBAIBEhMTG7spnDt37qBXr16QkZGBmZlZYzeHENIAKIAmhBDSYNzc3CAQCLB69Wpeenh4OAQCQSO1qnF5eXlBXl4eqampOHfuXGM3p0af4y8fhHyuKIAmhBDSoGRkZODv74+cnJzGbkqDKSkpee9709PT0bt3b+jo6EBFRaUBW0UIaSwUQBNCCGlQX375JTQ0NODn51djHm9v7yrTGQIDA6Grq8udu7m5YejQoVi1ahXU1dWhrKwMHx8flJWVYf78+WjVqhW0tLSwe/fuKuXfuXMH1tbWkJGRQadOnRAdHc27npycDCcnJygoKEBdXR3jxo3DixcvuOt2dnaYPn065s6dC1VVVTg4OFT7HGKxGMuXL4eWlhaEQiHMzMwQGRnJXRcIBIiPj8fy5cshEAjg7e1dYzn+/v4wMDCAUChEu3btsHLlSu76rVu30K9fP8jKykJFRQXff/898vPzee2dPXs2r8yhQ4fCzc2NO9fV1cWqVavg7u4ORUVFtGvXDjt27OCu6+npAQDMzc0hEAhgZ2dXbVsJIRRAE0IIaWCSkpJYtWoVNm3ahMePH39QWefPn8eTJ0/w559/Yt26dfD29sagQYPQsmVLXLlyBZMnT8bkyZPx6NEj3n3z58/HvHnzkJCQAGtrawwZMgT//PMPACArKwu2trYwMzPD9evXERkZiWfPnmHUqFG8MkJDQyElJYXY2Fhs37692vZt2LABAQEBWLt2LZKSkuDo6IghQ4bg7t27XF2dOnXCvHnzkJWVBQ8Pj2rLWbRoEfz9/bF06VIkJyfj119/hbq6OgCgsLAQAwYMQMuWLXHt2jX89ttvOHv2LKZPn17vzzMgIACWlpZISEjA1KlTMWXKFNy5cwcAcPXqVQDA2bNnkZWVhaNHj9a7fEL+MxghhBDSQFxdXZmzszNjjLFevXoxd3d3xhhjYWFh7M2vHC8vL2Zqasq7d/369UxHR4dXlo6ODisvL+fSjIyMWJ8+fbjzsrIyJi8vz/bv388YY+zBgwcMAFu9ejWXp7S0lGlpaTF/f3/GGGNLly5l/fv359X96NEjBoClpqYyxhiztbVlZmZm73zeNm3asJUrV/LSunfvzqZOncqdm5qaMi8vrxrLyMvLY0KhkO3cubPa6zt27GAtW7Zk+fn5XNrJkyeZhIQEe/r0KdfeWbNm8e5zdnZmrq6u3LmOjg4bO3Ysdy4Wi5mamhrbunUrY+x/n11CQkJtj0wIYYzRCDQhhJCPwt/fH6GhoUhOTn7vMjp16gQJif99Vamrq6NLly7cuaSkJFRUVJCdnc27z8rKivtZSkoKlpaWSElJAQDEx8cjKioKCgoK3GFsbAygYr5yJUtLy1rblpeXhydPnsDGxoaXbmNjw9VVFykpKSguLsYXX3xR43VTU1PIy8vz6hCLxUhNTa1zPQDQtWtX7meBQAANDY0qnx0h5N2kGrsBhBBCmqe+ffvC0dERP/74I28uLgBISEiAMcZLKy0trVJGixYteOcCgaDaNLFY/M72VK4CIhaLMXjwYPj7+1fJo6mpyf38ZsBal3IrMcbqteKIrKxsrddrK68y/UM+z7p8doQQPhqBJoQQ8tGsXr0ax48fR1xcHC+9devWePr0KS/oa8jl0y5fvsz9XFZWhvj4eG6U2cLCAn/99Rd0dXVhYGDAO+oaNAOAkpIS2rRpg4sXL/LS4+Li0LFjxzqX06FDB8jKyta4xJ2JiQkSExNRUFDApcXGxkJCQgKGhoYAKj7PrKws7np5eTlu375d5zYAgLS0NHcvIaR2FEATQgj5aLp06QIXFxds2rSJl25nZ4fnz59jzZo1SE9Px5YtW/DHH380WL1btmxBWFgY7ty5g2nTpiEnJwfu7u4AgGnTpuHly5cYM2YMrl69ivv37+P06dNwd3evd/A4f/58+Pv74+DBg0hNTcXChQuRmJiIWbNm1bkMGRkZLFiwAJ6envjll1+Qnp6Oy5cvY9euXQAAFxcXyMjIwNXVFbdv30ZUVBRmzJiBcePGcS8a9uvXDydPnsTJkydx584dTJ06Fa9evarXs6ipqUFWVpZ7qTI3N7de9xPyX0IBNCGEkI/K19e3yvSCjh07IigoCFu2bIGpqSmuXr1a4woV72P16tXw9/eHqakpYmJi8Pvvv0NVVRUA0KZNG8TGxqK8vByOjo7o3LkzZs2aBZFIxJtvXRczZ87EvHnzMG/ePHTp0gWRkZE4duwYOnToUK9yli5dinnz5mHZsmXo2LEjRo8ezc1NlpOTw6lTp/Dy5Ut0794dX3/9Nb744gts3ryZu9/d3R2urq4YP348bG1toaenB3t7+3q1QUpKChs3bsT27dvRpk0bODs71+t+Qv5LBOztf9UIIYQQQgghNaIRaEIIIYQQQuqBAmhCCCGEEELqgQJoQgghhBBC6oECaEIIIYQQQuqBAmhCCCGEEELqgQJoQgghhBBC6oECaEIIIYQQQuqBAmhCCCGEEELqgQJoQgghhBBC6oECaEIIIYQQQuqBAmhCCCGEEELqgQJoQgghhBBC6uH/AMUS3g3X/UIyAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtcAAAG1CAYAAAAyWtiRAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAvKRJREFUeJztnQmcjWX//y+UkVZRSkKleJiiTVRIm6THkkor7SWhSFRCypLKEm1oU5RSpHVaeLQpFU9CpYVKaEFoo3T/X+/v87vO/z5nzpk5M3PGzJzzeb9e55k559znvq/7vvTM5/6ez/X5lguCIHBCCCGEEEKIIlO+6LsQQgghhBBCSFwLIYQQQgiRQlS5FkIIIYQQIkVIXAshhBBCCJEiJK6FEEIIIYRIERLXQgghhBBCpAiJayGEEEIIIVKExLUQQgghhBApYrtU7UgI8T/++ecft2rVKrfzzju7cuXK6bIIIYQQZQD6Km7atMnVqFHDlS9f+PqzxLUQKQZhve++++q6CiGEEGWQ7777ztWsWbPQn5e4FiLFULH2/3HusssuKd33X3/95V599VV38sknu+233z6l+xYlg+Y0/dCcpheaz8yZ040bN1pxzP8dLywS10KkGG8FQVgXh7iuXLmy7VfiOj3QnKYfmtP0QvOZeXNaroiWTi1oFEIIIYQQIkVIXAshhBBCCJEiJK6FEEIIIYRIERLXQgghhBBCpAiJayGEEEIIIVKExLUQQgghhBApQuJaCCGEEEKIFCFxLYQQQgghRIqQuBZCCCGEECJFSFwLIYQQQgiRIiSuhRBCCCGESBES10IIIYQQQqQIiWshhBBCCCFSxHap2pEQxcl//vMf16pVK7d+/Xq32267FXo/5cqVczNmzHAdOnRwxU32oBxXPqtySveZVSFwI5s4lz04x23eWi6l+xYlg+Y0/dCcpheaz9LJihFtXWlFlWuRUi688EITsDy23357t99++7nrr7/e/fnnn8V+pevUqePGjBkTeR4EgbvuuuvcLrvsYuIcVq9e7dq0aWO/r1ixwsb53//+t9jHJoQQQojMQJVrkXJOOeUU9/DDD7u//vrLffTRR65r164mYm+//fZtdrW3bt3qLrvsMvfCCy+4OXPmuMMPP9xe32uvvbbZGIQQQgiReahyLVJOVlaWidh9993X7Bcnnniie+211yLv//PPP2748OFW1d5hhx1co0aN3PTp06P28dJLL7mDDjrI3scOQpU5WTZv3uzOPPNM9/rrr7u33norIqwBkT9z5kz7nePDoYceaq8fd9xxke0mTZrk/vWvf7lKlSq5+vXru3vvvbdI10QIIYQQmYEq16JYWbx4sXv33Xdd7dq1I68hrB9//HF3//33uwMPPNC9+eab7vzzz3d77LGHa9mypfvuu+/c6aef7rp37+4uv/xy9+GHH7o+ffokdbxff/3VtW3b1q1cudK98847JvATMX/+fNekSRMT4Q0bNnQVK1a016dMmeIGDhzoxo8fb8J74cKFVgXfcccdrQofT8zz8GzcuLGAV0kIIYQQ6YLEtUg5WDF22mkn9/fff5voLF++vAlV4PmwYcNM0DZr1sxe23///d3bb7/tHnjgARPX9913nzvggAPcXXfdZe/Xq1fPffLJJ0nZSm699Va38847u08//dTEel7496tWrRplFxk0aJAdG4HvK9xLly618cUT19ws3HLLLQW6RkIIIYRIT2QLESkHGweLBN9//30ToxdddJHr1KmTvffll1+633//3Z100kkmwP1j8uTJ7quvvrJtEMZHHXVU1D69EM+Pk08+2f32228m4AsDn2Ucl1xySdT4brvttsj4Yrnhhhvchg0bIg8q70IIIYTITFS5FikH+0TdunXt94ceesg81Q8++KAJVmwb8OKLL7p99tknl1e7qJxwwgmuR48ern379ubtHjt2bIE+78c3ceLEXAK/QoUKcT/DuFMxdiGEEEKUfSSuRbGCJeTGG290vXv3dueee65r0KCBCdFvv/3WLCDxYCHhrFmzol577733kj4m1evnn3/etWvXzuL47r777rjbeY81ySKe6tWruxo1arivv/7anXfeeUkfUwghhBACZAsRxQ7JHVR977nnHvNDkz197bXXukcffdSsFgsWLHDjxo2z53DllVe6L774wvXt29d9/vnnburUqe6RRx4p0DFJKMH7TcX86quvjrvNnnvuaWkkr7zyivvhhx/M0gH4p/FRI8qXLVtmfm+iBUeNGpWCqyGEEEKItCYQIoV07do1aN++fa7Xhw8fHuyxxx7Br7/+Gvzzzz/BmDFjgnr16gXbb7+9vd66detg7ty5ke2ff/75oG7dukFWVlbQvHnz4KGHHgr457p+/fqEx65du3YwevToqNfmzJkT7LjjjsFVV11lx2UfM2bMiLw/ceLEYN999w3Kly8ftGzZMvL6lClTgsaNGwcVK1YMqlSpErRo0SJ49tlnk7oGGzZssOPwM9Vs2bIlmDlzpv0U6YHmNP3QnKYXms/MmdMNKfr7XY7/KWmBL0Q6QRTfrrvuapVwukOmEhrzkAF+6qmnWgdMUfbRnKYfmtP0QvOZOXO6MUV/v2ULEUIIIYQQIkVoQaMQSXDhhRe6X375JdLdMRmyB+W48lmVU3p9syoEbmQT57IH57jNW8uldN+iZNCcph+a0/RC81nyrBjR1pUlVLlOMWvWrLEoOBqjkIpBh8B///vf7o033nCZBK3EaSnuH6RwsLDxm2++KemhCSGEEEIUGxLXKWTFihXu8MMPd7Nnz3Z33HGHpUyQREFTFVp5Zxq0DF+9erVbtWqVe+6556y5Cm3OS7sPSwghhBCisEhcp5CrrrrKqrTz58+3joQHHXSQa9iwoWU8h3OayXimyQmd/zDMn3XWWRYF5xk8eLBr3LixNWCpVauWbce+yWMeOXKkteomRm7o0KFRx+fYtOg+7bTTXOXKlS0vet68edYVkUoyzV2OPvroXJ0Gfbtxcp9pNf7YY4/l2u+kSZNcx44dbb8HHnhgrhzqeLAtY917771d06ZNLRKP2D0P8Xq77bZb1GewXXA8T506daIq4P7hr1O893xsHzc2xx57rB2DFudcl/C5czPE9tOmTbPM7UqVKrkpU6bYdWbO/Oeuv/56y8sWQgghhMgPiesUsW7dOhNzVKgRsbF4EUnXQIQ128+dO9e99tpr1rCkc+fOUdsjAl9++WXb5xNPPGF5zW3btnUrV660z91+++1uwIAB1mI8zK233uq6dOli7cfr169vjVuuuOIKa9H94YcfmkgM5z7PmDHD9erVy/Xp08ctXrzYtqVd+Zw5c6L2S/YzNwGLFi2y1bU0WOEcCnJ9nnrqqVxdD/Pjgw8+sOo3D84dkd68eXN7j7xs/x6PO++80wT9EUccEWlljkjmvLHl0NCGGwTmIEz//v3tGtB2vXXr1u6uu+4ygc7Nzdtvv21j5zolYvPmzbbCOPwQQgghRGaiBY0pguowwhVBmxeIPOwiy5cvNz82TJ482SrcCMkjjzzSXkMAIu5oukJXQ6wlNFQhOgaRSIUZgY0IDgtWhDEiGPr16+eaNWvmbr75ZhONgIhkGw+ClMV6VMbBV9l5nWN62Oacc86x34cNG2YNVqjQn3LKKQnP9d5777WKN9fl999/t0p+Tk5Oga7rHnvsEfmdsSOiuU5ARZ8HMGZuNmhEk52dba/x7UEYrif7W7p0aWQbuOaaa9zpp58eeT5mzBi7GfGv3X///XmOm4Yz3HwIIYQQQqhynSKStQ1QHUVUe2ENiGcq27wXtkMgrD0sCGQ7hHX4tR9//DFq/4ccckjU+3DwwQdHvfbnn39Gqqsc85hjjonaB8/DY4ndL5V57Cyxx46F6jYV9I8//tgqwHXr1rXW5Js2bXIFZcKECVa9x44SFtzeZtOhQwerZPsbC6DLIzcELC5lvFxTv30YX+kGsi0R8OEblu222y5qm1gQ4nzOP/CWCyGEECIzUeU6ReBDxr/72WefpWR/sQ1C2He812ItDuFtvDc53muxnyvMePLbB0HsCGrgJ+IY/zUe50svvdRuFGJvSuItKKQ6TwIL9piwyPfWj3bt2lmFfsiQIVHvkdJSu3ZtN3HiRFejRg0bLxXrLVu2RG0Xz8ZTEEiF4SGEEEIIocp1ith9993NenHPPfeY4IuFjGRgkSGVzXB1E5sC71OZ3tYwnnfeeSfqNZ4Xx1gqVKhgP//44w/7SQWaKnb4elHpjrXbnHHGGe7GG2+Msm4Awpz0EUQzizDDCyHXrl1rNhqsIieccIKd5/r16/MdIzcE3ACEvex///23++ijj4pw5kIIIYTIFFS5TiEIaywVTZo0sSoqVVaEGYsWSeTAanHiiSeaTQPLBN5e3sfvTFpFXtaD4qJv375mpTj00ENtbM8//7x79tln3euvv17kfeOzJvcbSENhsSWJHFhDAOsFCxARzj179jRB65M+vAin+szYLr/88si+gBQS0kIY56uvvup+/fVXe3iBXKVKFUv6wE6CWMYKwsLFZMDbPWLECPs2Ag/9qFGjIjdHQgghhBB5IXGdQvD2EjVHRB7pG3h3qc6SfY24BqqrZD5jc2jRooVZI1gUOG7cOFcS4FUeO3asLWBEVO63337u4Ycftui+ooIdgwcgdrnZYEEmizF9tf/xxx83gc92VJgRzAhpL8ix2fDA1hFbtSY1BUFNvGAYxs8CzCeffNJEO1YQjskizGTOy89d165dbX4uvvhiSxnBT10QFt/S2rzeqQTbDNdw8eDWuaw6omyiOU0/NKfpheZTFJRygQJ8hUgpLBaleo4YLy5xTRyixHV6oDlNPzSn6YXmM3PmdGOK/n6rcl1MUCGlEQzWD1E0qPaTM02VfVvwn//8x2II8WjHNrkpCNmDclz5rMopHVtWhcCNbOJc9uAct3nr//eYi7KL5jT90JymF5rP4mfFiLYunSjTCxr56j9eh768spe3FfiW8RgXN1gjjj/+eLNY+O6J2BliEzGEEEIIIUTxU+Yr1whpPLZhihKLhkuG9tdkGxcFxG5xQ8oI549/Gz/xDjvsYNnOzzzzjJ1DcYJ4p116GI7JzU04i1sIIYQQIpMo8yoIIU1yRPjB4jlYsWKFib1wvBupD7zGV//AT57TapyFh+yPhie0H6dNOU1X6AJI58TYBA06EFIpJgGD7YiMC9tC6PznISqONBAawzBG2pKHm7D4cdDBke2oQrNQjzi5RJCSwb5Gjhxpi/YOOOAAE9ssDkRoA+kbWBtmzpwZGSuRgeEowGTOlQYsvrU6PiQWHfp909iF6D6uHakc2CnYjnngPNq0aWOi39+8sMhz+vTpkX1jnyHRw8P1Z1+kjXh+/vlnW1Toq/McMyzqL7nkEluMyXmzeJFFmh7auiP4f/rpJ3tOO3Oen3322ZFtbrvtNnfsscfGvc6Mg3MgCUapIUIIIYRIa3GdKohpI36NuDxSLUihwOiO2F24cKGJVmLhfHe/Dz/80JIoiNxDAL/yyiuW/pGXeR5xSrdChC7CH1tLLDfddJO76667bP9Uz0mqSATCmlSLN998M89zQxySYEKbdTKsEYhhYZnfuXpIFGnUqJFtQ0t1v2/asNPmfMmSJW7PPfe082L8COB58+aZoGb/XANuILhO/uYGIc41J3bPN+DB6oLAR0h7aC9OZOCiRYtsX0QZIpKBnOuaNWu6p59+2qr5AwcOtHi/p556yt6ntTyxfOwX3nrrrajn/pjxkkS4VieddJIdg0jFeB7szZs32yKI8EMIIYQQmUmZF9cvvPCCVVvDj2HDhhV4P4hkRBTVXywdiMgrrrjCKsJUShHGvOcrpghPOvuddtpp1gWQLGbEdiIQyVQ/ietr2rSp2TiolvtsZg8imMxrKsEI/nfffdfalcfjzDPPtPbebE/ll8ru+PHjc4k7RC2v08WQ6vyjjz5q+50/f769n9+5evB2E1PHezz8vqngU2WnYvz999/b5xDbzZs3t31PmTLFXuemAhCxXlxzY8C1C7/GT84pDIKdc6XTI/PLdfPjZ6Uv4puKP9VrhPdFF10UEdexgp6fvI8oRtBzDlyP2GOSq+2vLfnfYbEfZvjw4ba62D/Cre2FEEIIkVmUeXFNqgO2j/DjyiuvLPB+Yhu4IN6uu+466+xHtRLRToXVV3MR4ohqxPIFF1xgAjJsY4iFDn9Ug2vVqmXWEC/kYqvD4fbe3ioRto/EdjzEb75y5Uqzhuyzzz4mPKnUUtH2UAGnEuyhMQrnxPkkc66JrhHguw6Pmc9xPBrEeKgSI7z98Th3KszYNHzF2ItrL3Rjq8jhY3BTgzUlfF1o4MONA5YTxk/zmPD4OaYX134RqBfcH3zwgR0X20cY5hgxT7v2WH95mBtuuMFie/wjbLkRQgghRGZR5sU1QgsBFH74xYR+YV04yhsRlWg/YRCbxL8hVrERINrprOhTOBDINIx54oknTARjRaBKG8+TS3tvfM4IQkQ4Yo59Q2yqRzhv0bfzxpKQF4hqBD7VaawZVLrvv//+fK5c8uea6BoBHudw2/FkYN/MESI3LK753Qvd2MYwsZnOHNNfF5rFcA74rvGhM34q0+Hxs38EPd5vfuKv9oKe43qfe5i2bdtaZZ3t8wJ/OHMbfgghhBAiMynzaSF5QRUTqOJiPYDw4sa8wJuMFQGrha/u4pMOQ4WWluE8Bg0aZFXf2bNnu9NPPz1qO6wHa9euNU+3twzgSS4OWESI2EfQe2ixzvFoyw54xLkJoFKd7LkmC/vkeLQy9wKZc+eYWF28MMYyQqdKbgYQughbbBoPPPCACd14Qj4RjJ9j0UY+vEgzVtBzbVi4yAJKqtuIa/zi+L7j+a2ZL7ajcyQi3I9fCCGEECJtK9cIMryx4QfJEr6qir/ZL1SkQjlgwICk9ov3mKxqxDiLEEn3CFeQ8Xrjm+b9b775xhYL8r5v7R0GKwi2Alqcf/311+ZJTkUGNkK0W7duVq1FTCJU+/XrZz+xoISrvsT1IXixpyCkuS5ebOd3rgWBfZE8ctlll1nqB/s7//zzrbrO6x7ELFV/L3T5lgGbBpX9WO9zMsfk5iEnJ8ctW7bMFltSAQ/jfdfs3wtprCb8+2EhZ6JjsogTDzc2Er/gUgghhBAibSvXpHSEY9wAgeuF0EMPPWR2Afy4vI43+eSTT853v6NGjbJFiFREq1WrZqI1vFCQKjWCdPDgwWbDQOAhFvE7x6ugE1tHggWC/LDDDjPR1q5duyKdO+IYAYvHfNWqVSZSOT4LB8Nikaow40c0s7CQqvGDDz6Y9LkWFHzgvXr1ssWeWDMQtbQZDVs7GB8ReuGKMb9TzY5XRc4LFmOSYNK5c2cT0Sx8pIrNgtEwHJNr4/fvBf2LL76Yy28dZvTo0TZWBDYV7IMOOiipcS2+5X9WoOJo2bp4cGu1P08TNKfph+Y0vdB8ioJSLggbkkXagagnb1v5zNsObkxIDWFxY3GJa+IIY33oomyiOU0/NKfpheYzc+Z0Y4r+fpd5W4gQQgghhBClhTJvCxElD4sfyZfGmoGHOhVg7yDBpEOHDi5VYOHBFpLsotaikj0ox5XPip+NXViyKgRuZBPnsgfnuM1bC5bSIkonmtP0Q3OaXmg+i58VI9q6dEKV6zSHxYtFsYTweYSuf5BZTQdHOiWWJnwr9jAsYiWdhWY7eL+J62PxYvjcUinehRBCCCEkrkW+IKaJM+SBOCWCkMWKpRnSQli4ydh9ExgWfHJzIIQQQghRXEhci3yhScpee+1lD2wftGWnCyEdFuNBsgYJLVhFiEMkpWXs2LG5tiPJhXQT9k/iy9VXX51wDOSIs00yFXOyxkn2YAwTJ06MNBPCFuJtK/xOG3jSSXxV3ndw5NzOOussq4TT7IYIwcLmfgshhBAis5DnWhQIGsw8/vjj1gkzURWYjOyaNWu6p59+2rahnfnll19u4hjRCvfdd5/r3bu3ZZC3adPGVubSDCYWwmx69uxpueJ0j+S4eYFPm8hBxDORgonAIoJthJXBRAcCQpoVxHTTbNasmR2PKj2NZ7wVJl4bdLKyeXiKEmMohBBCiLKNxLXIF4Qtlgqg8yMimdd8RTgWYm1uueWWyHMq2PPmzXNPPfVURFwjWPv06WN52J4jjzwyaj90eqQBDQslyfOmEU1+wh9/NXnieQlr4HyoqiOKqch7uHHg5mDSpEmRtu6Ib6rYVLbjZaQPHz486nyFEEIIkbnIFiLypVWrVpawwWP+/PlW2aXaTGfKRNxzzz3WuIcGOgjZCRMmuG+//dbe+/HHH63pDW3F8+Laa6+1rpJvvvlmvsIaEMsnnXSSWUGoShcGOkp++eWXbuedd7Zx86CiTaOg2JbqnhtuuMEq7/6BrUQIIYQQmYnEtciXHXfc0ewYPKguU9Wlgo2IjceTTz5ptgs8z7RmR5RfdNFFltjhRXAyIJTpKElb82SoUKGCRe3RAZMbgsIIbKrf3BT4mwn/oK06dpN44BknbD78EEIIIURmIluIKDDYJbCE/PHHH3HfxztNK3VakHvCVV+qwnXq1LHkEURwImgP/+9//9tELcL57LPPzndsCF3a0p9xxhm2bxY3NmjQIO62+KdZfBkGYU66yJ577imRLIQQQogCo8q1yBd8yWvWrLEH1eAePXpYhRfhG48DDzzQffjhh1ZxpuJ78803WzReGBYc3nXXXe7uu+92X3zxhVuwYIEbN25crn117NjRPfbYY1b5nj59elKzhcB+5pln3FFHHWUCe8mSJXG3Q+CzSPHzzz93P//8sy1mPO+881y1atUsIYQFjcuXLzevNYsqV65cqX8tQgghhMgTVa5Fvrzyyiu2iNFXnevXr29JIMcdd1zc7a+44gpbhNi5c2ercp9zzjlWxX755Zcj23Tt2tV8zKNHjzYLCYKWanM8eJ1FhhdccIFVzE8//fR8x0xVGjHOAkpfwY7lsssuM+F8xBFH2M3CnDlz7JzweLMgkuNs2rTJ/N74wwtq91h8S+uUV7+5AXjppZfc4sGtbeGoKPtoTtMPzWl6ofkUBaVcQNaZECJlEMW366672uLG4hLXp556qsR1mqA5TT80p+mF5jNz5nRjiv5+q3ItigSVabKly0Ibcd8KnkWP24LsQTmufFbllO4zq0LgRjZxLntwjtu89X9RgaJsozlNPzSn6YXmMz4rRrTdxjNRdijznuv777/frApkInv4ip87kVjbAhYAxGCiSLVkoVsf+yFFoqR45JFHbAz/+te/cr2HZYP38BSXRpiXa665Ju45kSddXNAlkmMIIYQQQhQXZV5c46dFTLOAzsNCNBqDkJGMr9eDp7ZWrVrugAMOcKXpq4miROSRGU2DljAPPvignWdR8dF5ZYl4YyYRBM82X/UURbzjoArfxAkhhBBCpJ24rlevni22oyrt4XfSHugM+N5770W97qPfEFt01mMbcpcbNWoUlUaxfv16S46gCQrvk4Dh22TzGTj00EOtQhyukJMBTTW5UqVKtvDv3nvvzVXxJuqtZcuWts2UKVPMroCt4s4777RzoWV49+7d8xXetOYmpu6hhx6KvEaiBecZm8lMtZ5rUr16dWuMQl7166+/HrUNle5bb73VdenSxbxGtCxHrF599dU2LsZbu3Ztu25hSNog1aNy5cp2nWbNmuVSQWHH7CvgjIMYPtJDaGDjr7Mnv38D/psOFmKSfc1+6BQphBBCCJG24hoQzFSlPT71AQHrXyeTmUq2F9eIqsmTJ5uthKg2ugHSanvu3Ln2PvFxS5cuNWFF/Nx9991niRZAl0JA6K1evdpylQGhPHDgQDd06FD7zLBhw2w/jz76aNR4+/fvb22/2YZuh37MiEl+sj0CMRkLw8UXX2xtxX///Xd7zmdOOeUUE6RhqO5j3CdbmiQPtiFKz3dN9CDwEZlsw9iJykOkcgwi6zjHWLsJrb9J5SDWjmNwU7Ju3TpXVAo7ZuB63H777Xazw/ySWx1Lfv8GwvM1YsQIm69DDjkkblQhiyDCDyGEEEJkJmmxoBHBjIeXr+wR0YgshDWVX4QTYJ1ABLEtPxG+iONmzZrZ+/vvv79VJR944AH7LAKOyjQxbRAWlFSzgQoz9hPPoEGDLLvZR8VREUWgs0+i5zyMNTZOrkqVKm78+PHWLIWKd9u2bU1UEheXF4yRsVNxJaoOcT1q1Cj39ddfR22H+OThodrLQkSEM5Vpz/HHH+/69OkTec51oBp97LHHWhWXynUsVISJ2wOuK4KcGxDEcCKo6CN8wzB/VMeLOmZsQcw9xwh/Pkwy/wY8Q4YMsW6RiUCkc4MhhBBCCJEWlWuq1LTjplEJwuqggw4yAYxA8r5rvuJHPOFF/vLLL62yiWDCbuAfVDH9Ysdu3bpZG+/GjRu766+/3r377rt5joHj81lafof3edttt+VaQOkFe5iGDRuasPZgw8BPnQxUr7GsUHFlHFR741WByZPGsoJlgrFRiY2tAseODeHMwk3sNzRSoZ15LOFqLj5w7Bn5jZ3qdmyLcURsKsbsc67jVZk9yfwbyGv/YW644QaL7fGP7777Ls/thRBCCJG+pEXlum7duq5mzZpmqcAr7auONWrUcPvuu68JY96jwulFG7z44ovWICQMvlpo06aN++abbywH8bXXXrMmIvigsSDEw+9z4sSJ1hkwTFg0ewEaS2xDEKrEeIKTAaHKDQBdD6le48WOBZHKeTB+rhceY5qzxC4AjB0b7cDpUog9hiov9o8TTzwxyptcmLGzuJBxhIm1bhR2zMC2jCMRyfwbyGv/sdvHfkYIIYQQmUlaiGvA7kF1GnHdt2/fyOstWrQwYYhNgWo0hBe5hb/+j4XqN3YOHs2bN7f9IvSoivoUCg8eZ8Q8dgzE7rZk9913d+3atTNftLfBxPLOO+9YFZqFh15cssAyGahE022RB+IWuweeao5bnBRlzPmR7L8BIYQQQoiMFdc+YSMslvgdfy7VTr+YkVxsqqIsYKPCip+Yr/MRcwhJxDQLE0mIwK6BP/eFF16IZEpTYaUySltwKub4hKnE4rvFOsHvCFA+R0Qggr93797Fev54rfEY4wOPB75pFl6yIJCKLgv/kqmM49/GooK3m9bjZGjjMy/OPOqijjkZkvk3IIQQQgiR0eKaxYwsBgwnZSCuN23aFInsCy+OozLNYjSqzYhFLBA33nijvU91Gi8tlVKENJVrPNiA7YJFe3iEEeG8R9X80ksvtTi6O+64w6rc2AkOPvjguA1TUg1j5JGXSMabffTRR1vqSb9+/ZJKtUCEjhw50n3xxRdmbyEOD6sMQru4KeyYkyW/fwNCCCGEEAWlXEBnDCFEyuAGgG8vqIRTBU8lfDPDzQ2LVmO97qJsojlNPzSn6YXmM3PmdGOK/n6nRVqIEEIIIYQQpYG0sYWI1EYbEkE4ZswYXdYiXJPsQTmufFbllF7DrAqBG9nEuezBOW7z1sRpKKLsoDlNPzSn6YXm07kVI9qW9DSUKVS5LiFIwWCRXuwjr8Yr2woWEeJHLm4435kzZ0Z9TUMzGqLxFi9eXKR9+9blv/zySwpGKoQQQgiRHKpclyAIaZq/hClKXjL2eeIB4+VcF4TijtiLBw1dOnXqZAsn6ZJId8ttASkyPlpRCCGEEKKoqHJdgiCkibULP2iDDqSUUHmlc6GHKiyvUZUNV2fJ8SY2kP0hTOkw2L59e0tNoesgCR80gAlDbB9Rd8QIsh351WELRDjh5LHHHrMuhSSHMMZzzz03qgOjHwft2tmOxBQSPj7//POkrgPnRafEVatWRQlrogyJy6OSTfIKzXn8uQNNfojp45rxPrGJLFDg2vnYRd5jbHxT4M+NaEbOjwSS1q1b2+tUymkcxPXietCM5+effy7QfAohhBBCSFynAf3793cjRoyw1uC0/KbZCitgEbsLFy60Cjki1LcNJ3ubPG6iBBHA5HXTbCcR2DWwiXz88cdm40C8erEa5qabbnJ33XWX7Z/qOTF6+bFmzZpILjnt2xHvHkTwvHnzLAJx0aJF7swzz7RzoboN5JojwN988033ySefuNtvv93EMV05n3nmGduG81u9erUbO3ZsZL+PPvqoVavJtKbpDuKe7p1keTN2rscPP/xg3SiTgTGwwjj8EEIIIURmIltICUJjGsRgGDKWC5qzjEim8hu2dTRq1CjyHGE8Y8YMN2vWLBOsiGwqvaeddppVo2vXrm3CMhFhkbz//vtbxjfVcER8ePxDhw6NCGUEf9u2bd2ff/5p1fFE9OrVy/ZJm3Mq3h7GiGWGn3S+BKrYCF9eHzZsmL2HlYQscT+28DXwDX9iG95QsSe723PbbbfZ+bNPz0MPPWQifdmyZe6ggw5yeUFONg2EhBBCCCFUuS5BsC5g+wg/rrzyygLvBytGGEQvQpSOkghLBDBVbV+5RogjqBGj2B+mTJlinudEfPTRR1b5rlWrlolxL6D9/jxUzT2+YU/YPhIPBD4C9oEHHoh6nUo0/nGELeP3D6rb2F6A6jvC+JhjjnGDBg2y6nYyYKEJQ0V+zpw5UcehGRH4Y+UFzYbIxPSP7777LqlxCCGEECL9UOW6BKF6XLdu3bjv+Q6I4R4/2DMS7ScMwppK8J133mn7p3MjnmoW7wECecGCBeZffvXVV63L5ODBg90HH3yQq8r722+/mS+ZByKcjoaIap77/XnCQez4nCG/duWI+3bt2ll1nHP1beK5QaAjJMKen2F8tZyOmIzjxRdftPOggowtpUePHnkeM/Z6cSxuHrCVxBLu6pkIvO5FWYgqhBBCiPRB4rqUgogF/MLeshFe3JgXeInxRHfs2DEiHvFJh8ETfeKJJ9qDqi+ievbs2e7000+P2u6zzz5za9euNU83NgnAl5xKunbtajcTF110kYlxbg44ZyrXVL5pL58IxkS1nwcV5IkTJ5q49gkg7CM/aHmOR7tOnTpFTloRQgghRGYjJVGCsBCOBX1hEHekWFBtbtq0qYla0jMQmQMGDEhqv3iKyaqmGksF+eabb46qIOP1/vrrr20RI2kaJGzwfr169XLtCysIQnXcuHEmYEnVKI4MbCrYCGyENhXsvn37uvPOO8916dLFqtGI7Z9++skWaWI/wc9N4gcJH1hH1q9fb9YOrDCA7YVz51xZ3Mn1jPW3e1gYiSgnY/v66683v/aXX35pCyknTZqUq3IuhBBCCJEIiesShMV5sbYDBC7VYr+o7pJLLjGPMK+zCO/kk0/Od7+jRo0ymwVxeAj1fv36RSVYUKVGfGMFYcEhYvyJJ56wKLt4FfRHHnnEFlmykJEqL3YTrBypBjGNwEZoI/ZZuIinuk+fPu7777+3c+GGA5+2r0ojjFeuXOl22WUXSxIZPXq0vUd8H4sMWVhJRRyRznnEgwWTVPu5TlxfbnoQ5+zP23MKw+JbWtu4UgnWIG6GFg9uHWXDEWUXzWn6oTlNLzSfoqCUC8KmXiFEkeFGZtddd7XFjcUlrqnGS1ynB5rT9ENzml5oPjNnTjem6O+30kKEEEIIIYRIEbKFiGKBBZR4xWli07hx4zJ/lVkgSrMZmugkS/agHFc+6/9nd6eCrAqBG9nEuezBOW7z1v8lsoiyjeY0/dCcpheZPJ8rRrQt6SGUScqXtGBh0VnsA69rpsN1iCfkuGYdOnQokTEJIYQQQohSXrlGSLNwLUxRMoOxkLPQTZFqorA+LHmZhRBCCFFmPdcI6b322ivqQTyctxZQwQ3nO/PVPK/RAAX4yfOXX37ZUjXY39tvv22JD3Two/017bePPfZYa5Li8Z+jAQnRbmxDEgVRc2HYFznLRLmRqcw+aazieeyxx6xDIo1ZGPu5554b1ZXQH4cIObajxTcpHp9//nlKrl+y55nf8Z977jlLAmEfdG4kaePvv/+290ge8QkdYRHKMR988ME8x0fyCcdjv9nZ2dZh0UN6R2zTGqr1vgENkD0d79sNIO0k3ns+FYQ0Fq4Hx6hataqdQ7jjov/3NW3aNOs6yRhplMPNGc1s/OeI59O6XyGEEEKUCXGdKohcIxOaNt+IZQQRjUEeffRR60ZIp0K6+a1bty7qc+Qpk6OMICV2jmxo3wkRIUZlvVOnTtZaGxGG2L766qsjn2dbcp9poY0wRLBh3YjlpptusuPQgIWqOoI1FSR7nnkd/6233rKoul69ermlS5daK3IE6tChQyOdEBGqNLTxkB9Ny/TOnTvnOT6uL1F6eK+bNWtm15emNMnCvHBcHkTucQPkm8rQbMa/x4OIQG4efDt4boIQyZwzNxfE6tFYJ7ZrJP92OHf+7XDtuE6cP1GIzDfXcsaMGXne4LDCOPwQQgghRGZS4uIakUZzj/Bj2LBhBd7PkCFD3EknneQOOOAAq17fd9997o477rAmIw0aNLAmIVSfYyutdCfkcwcffLAJ1B9++CEipGinTfYyzUrIgqYCS9bz5MmTLR8aEKkcg2ovwo/3qaLTFTEMQpXqKGNBzL377ruRfSSCpiax14bKqgfxmOx55nV8nwdNAxfOg+vBDQMiGzhvcrap0nuw8px55pkJG7N4uBHh5oTmLoyViJv8qt1huOHx32iQ842I5mYCOLZ/j5samuwwLirkwHHpOMkNB4sqEcuffPKJ3UCEYX7ZjgWY5I6PGTPGuj3yGuO+//77bdyJ4N8J7/uH72QphBBCiMyjxMV1q1atzPYRftAJsKD4aqWvOFNRPuaYYyKv4aNt0qSJVSfDUE310JkPEem3oRpNBTMsbqlsUvlcvny5bfPRRx9ZNZZOhlhDELDw7bffRh2HarrHN44J20fiQUOU2GsTbt5SkPPM6/icJzcn4fO87LLLTMhSnfbVa++N5waEGwhf/Wa+wp9NdH2pmDNPsWNLhgkTJpgonzVrVqQ1vIdrzSJPKtlnnXVW5PUvvvjCblC4YSCvEouJ3z7Rvx2yLTnvo446Kte4E4EQ53P+8d133xX4/IQQQgiRHpT4gsYdd9zRKovx8N3xwn5Xb9mIt59UQ/X5iiuuME9zLIhpKseIbR5UlBF9CDeeb9myJWr78CI57xmOtSfEQkU29tog4PGdF5S8js95Ur2mUhsLPmTANkJ1e968eVb1psrr7RkIc4RtQWF+Y73M8eaXtuY9evSwLpLhmwRgDrjhQMQzjjDc9NBpkWo+XRg5X6rasXNT1H87fFNSlEW4QgghhEgfSrxynRe+Qhn2+oYXNyYCa0jFihWtpXVYtOHfxRYR5r333ov8vn79erds2TKzAgAL/LAQIHBjH+yfxXr4h/F6IzTr16+fbzU6lRTkPPOC82SBY7zz9Dc4LOyjOkz1mmo+LcU9LGwMfybR9WWBJJV+f32Z302bNkUtEI2d3y+//NKdccYZ1n49VvwjzM8//3wTzVhWwgshmRfOCavICSecYMdkfvMDWweV/ffffz/XuIUQQgghSn3lmsVga9asiXqNr+GrVatm3mF8zIhXKqUIV8RSflCJ7Natmy2mw+pBlRm/LhaHSy65JGpbqp0Ix+rVq9uiP47rc6T79etnx8c3jC2C/SK2X3vtNTd+/HjbL+J23LhxZo0gaQSv8raiIOeZFwMHDrQkDT6PkEVQYxXhfG677bbIdlwDtiNNA392Mtxzzz3mV0fcYnNB4Ho7CdYLFiAinPl2AEHrkz7gjz/+sOrzoYce6i6//PKofydU9UkLef31192rr75q1Xfvc0cgkzjDvGInQSzzjQKV92RgcSP/5hg3N0yjRo0q1LcFQgghhMhAghKka9eueAJyPerVqxfZZunSpUGzZs2CHXbYIWjcuHHw6quv2jZz5syx9/nJ8/Xr10ft+48//gh69OgRVKtWLcjKygqOOeaYYP78+ZH3/eeef/75oGHDhkHFihWDJk2aBB9//HHUfvjMSSedFOy0007BjjvuGBxyyCHB0KFDI+9PnTo1qFOnjh2Dcc6aNcv2u3DhwoTj4z1eW758ecJrw/szZsyIe83at29f4PPM7/ivvPJKcPTRR9t13mWXXexaTJgwIerY//zzT1C7du3g1FNPDfKDfXMMrg/74vo2aNAgmD17dtR2nGPdunXtuKeddpod0/+z9PuI94CWLVvGfe/hhx+291977bXgX//6l10X5u0///lP1HX1+/dz5fnrr7+CXr162XXYbbfdgt69ewddunSJuu55sWHDBtsvP1PNli1bgpkzZ9pPkR5oTtMPzWl6ofnMnDndkKK/3+X4H5eBkP/MYkoqqbFZyyI+VIb32Wcfs4bE82eL/0EUH9VzFjeykDKVYPt56aWX3KmnnqpmN2mC5jT90JymF5rPzJnTjSn6+13ithBR+sHT/PPPP1v+Mzci4cQSkZjsQTmufFbllF6irAqBG9nEuezBOW7z1v/vMRdlF81p+qE5TS9Kaj5XjGi7zY4lMmhBoygd4FfGkz516lTLik5Fa3ni6vBek+KBb51UD7zOBWkwI4QQQghR2sjYyvVxxx2nltZJQj50Kt1DX3/9tUXnHXTQQRavx2LVJUuW2MJM8rNJGGGBZqohgg8hL4QQQghRXKhyLbY53bt3N5FLygdNd0gpocMkyR/ff/+9pbbAvffea4kdZG1TOSfJJHxzRIoLD/xRpLzcfPPNUTcB3BSQ3kJGN94pEkeAluZEJ5JGQzdFkkp8HCDpMb7DYxg6PLJ/IYQQQoi8kLgW25R169a5nJwcd9VVV5m4DUO8Hu3mp02bZlndiF7ELnnVr7zyimvRokXU9rSrx6Iyf/58N3bsWIvMmzRpUtQ2d955p2vUqJFbuHChiWO6Wp5yyinWGn3RokV2LMQ2Ih2wqtBBkuN7+CzbhrO9Y+MkWQQRfgghhBAiM8lYW4goGWhJTnXZN5KJxTd7ob08Od7katOVEk82eddhqDqTnU3zGNrWf/LJJ/ac1u2e448/3vXp0ycqqxsBf80119hzKuN33323VdDvu+8+V7NmTeuwSSLKkUceadvwO+/TRj0ew4cPtw6XQgghhBCqXIsSIT8PNw1mENQI2gsuuMDay9McJwwNfsJdGfFxI95pcuM54ogjoj5Dcxwa1ey0006RB2KaRBQEPSDO8YL/+eef5tNmIadvfBOPG264wWJ7/IPFmkIIIYTITFS5FtsU2qMjiLFedOzYMdf7vE53RXzYCxYssDxyvNl0kaQjI3aNguSSU/2Ozeq+4oorzHISC8cEukJmZWW5GTNmmDecPMyw3zsWtuUhhBBCCCFxLbYptCQ/6aSTbLHitddeG+W7pr05FWoWICLA8VOfeOKJ9hg0aJCJ6tmzZ0ca2NAuPQwpI9g8KlSokPD4hx12mLWwR+QnguPS3h07COL67LPPzuUPF0IIIYSIh8S12OaMHz/eHX300WbHuO2226Ki+OgAOXToUPfCCy9YZB+LGKlk00kJ6wbe6nD+du/eva0STZV73Lhx1ugmL/r162d2EhYw4r+mso3Yfu2112xcHt7zvvB33nmnGK+GEEIIIdIJiWuxzaG6/OGHH1o1+qyzzrIEEZJCOnToYK+RcU2V+tlnnzUrCN5nPoMPumHDhpH9UOH+448/XJMmTaxaTRMaH7eXiEMOOcTNnTvX4v6I48P7fcABB7jOnTvnGiM3AIwN/3dhWHxL62Jrf754cGu1P08TNKfph+Y0vdB8ioIicS1KBBYrsrAwEccee6z5rfNi++23d2PGjLGUj3isWLEi7uukgODjzgtE96pVqywyUAghhBAiWSSuhYjhp59+ck8++aR5wBNlWwshhBBCxEPiWiSELoh0JqQ6XBag0t2qVSvLyU6UKEK1nIzrX375JeF+9txzT+v4OGHCBPN7F5bsQTmufFZll0qyKgRuZBPnsgfnuM1b/38MoSi7aE7TD81p+rBiRNuSHoIog0hclzAXXnihdRqMhcV+dCUsSfA8Y70obkgGIfYOz3XstUEEz5w5M9dn8rOMFGcGtxBCCCFEIiSuSwG04yb2LUxRcpMRhzRSIVKuKLCwUAghhBBCJI86NJYCENKkZYQf3o7Aojwqu//9738j21PN5TVfveUnz19++WV3+OGH2/7efvtt99VXX7n27du76tWrWydCFvK9/vrrUccmb5pkjEqVKtl24WYp2EJ8m3B47LHHrOMh7cgZ47nnnut+/PHHyPt+HG+88YZtV7lyZUvc+Pzzz1NynTZv3mzNX7BtMF4WPdJUJhai80gFYRti9xYvXpxrG6rh/rz5lsB3VeR6ly9f3tJMwmCNYREmcYBCCCGEEImQuE4j+vfv70aMGGFdDhGXdCM89dRTTewuXLjQKuR0HyQfGhCQiNUhQ4aYAMaGQq50XnFEt956q7UQR5wiRLFuxELMHXnT7J/qeV6twwvC9ddf75555hmz0ZBrTSMYhDFxeWHIy+b4CO899tjDzpmxe2ijTpb25MmTTYhzs0KjGKhTp441rYn9JoHnnCvCO57o37hxY9RDCCGEEJmJxHUpgIYpVJbDj2HDhhV4P4hkuh+S24ylo1GjRtZgJTs726q0CGPemzVrlm2PyKaJymmnnWZV2UMPPTRuW3APIrlNmzZu//33t4rw3XffbdVyRHwYhGvLli1dgwYNTPC/++67llWdF+ecc06ua0C3Rs9vv/1mkXt33HGHjYF9T5w40TonPvjgg1H7Iiub63DwwQebEP/hhx/M0+1BaNMwplmzZlbpZxvGOH/+/EgDGTK1Ec2AkP/kk08SJocMHz7c7brrrpHHvvvum+e5CiGEECJ9kbguBZBwge0j/LjyyisLvB+sGGEQvdddd511GiQ9A8FKVdtXrhGgiGrE8gUXXGBilqpuIj766COrAteqVcusIQho8PvzUDX37L333vYzbB+Jx+jRo3Ndg3bt2kXex+KCKD7mmGMir7HYkgYynFMYRLOHmwy6Ooa3oZqORcZTv359uz5+GxZW0pTGC3ISRpgjqtrxuOGGG9yGDRsiD28xEUIIIUTmoQWNpQCqx1gc4uFtCOEEi7DFIXY/YRDWtPW+8847bf9UefFUb9myxd5HIFOVxStNU5WBAwdaR0TsFLFRdlSOsWDwQIRjt0BU89zvzxNOGMGDDfl5lfFwx14DxpdXZF5xUbFiRev+iBXk9NNPd1OnTnVjx45NuD0e96IsQBVCCCFE+qDKdSkHEQurV6+OvBZe3JgX+InxCXfs2NEsEgjY2K6FVHHxGI8cOdItWrTI3p89e3aufX322Wdu7dq15ummbTjV3vyq0akEOwuil3MK32RwI4BFJMx7770X+Z3M62XLlln13vP3339HLVjEb46ID2+DNYTFnyz4ZHtEthBCCCFEfqhyXQrA20s3wFjRSyMTqs34mxG1++23nwnaAQMGJLVffNZkVWPloIJ88803R1WQ8Xp//fXXtoiRdJKXXnrJ3sdGEQtWEMTtuHHjzLJCAgce7m0FVflu3brZYkWsHoyHGwJsLJdcckku73nVqlUt/YTFlVzHcIY2lfUePXqYZ5zrfPXVV9s1xmLiQWjzWr9+/cxrzjwIIYQQQuSHxHUpgJQO7032IHCpFsNDDz1kApLFd7yOqDz55JPz3e+oUaNMGBKHh8BEKIaTLLB+IL6xgrDgEDHOQr6GDRvGraDjPb7xxhtNlB522GFmNwn7oosbbjAQ//jDN23aZB7znJycXF0U2a5Xr17uiy++sA6Tzz//vN0YeIgI5FoQJfj9999bJT52USRwzVnoWNi0k8W3tHa77LKLSyVU67kJWjy49TZp8COKH81p+qE5FSKzKReoHZ0QcaEy//TTT5tdpiBwA0NqCIsbi0tcE7EocZ0eaE7TD81peqH5zJw53Ziiv9+qXIuMgio9Gd3etx6vxTopK3jPieu77bbbCn2s7EE5rnxWZZdKsioEbmQT57IH57jNW/+3WFSUbTSn6YfmtGyxYkTbkh6CSDO0oFGUGhC6eMPjxRB2797d3ovXtKYokAKC3SUMHmwsOHSoTFUDHCGEEEJkBhLXolRBA5Ynn3zS/fHHH5HX8IMTh8cixsKC+4nUj1j4+ic2dhCxzSLTadOmWd61EEIIIUSySFyLUgULJRHYLLT08DvCmg6SHhY20hmRBBWSPOhGOX369Mj7ZHdT6aaDJFVocqjffvvtXMejEh5OEqFaTZdKWq2TSkJ8IVYSIYQQQohkkLgWpQ6sGDRw8ZCWEtt6HGE9efJkd//997slS5a4a6+91p1//vlu7ty5UdvRfp30ELovhjtH5gXt0In+e//99y2ZhWg/mvEkgio3iyDCDyGEEEJkJhLXotSBSKbK/M0339iDxjG8Fhazw4YNM9FNh0jat1OBZpsHHnggal8IY9q804SGSnQyIMIHDRpk0YR0aiTy74033ki4PUIfe4l/UHkXQgghRGaitBBR6iBTu23btuZ9xivN7+R0e7788ktrHoNoDkMb9rB1BBDGBSW2wk0GeV7dKG+44QbXu3fvyHMq1xLYQgghRGYicS1KrTWE1A645557ot4jKg9efPFFt88++0S9h7c6DPaOghKbH413O9zZMhaOGXtcIYQQQmQmEteiVHLKKadYJRphi/UjTIMGDUzMfvvtt65ly5YlNkYhhBBCiFgkrkWphAg8FiH638PsvPPO7rrrrrNFjFSUjz32WOumhDebjkpdu3YtoVELIYQQItORuBallrxaj9KaHG82iwm//vpry6omxu/GG290pYXFt7Qutvbniwe3VvvzNEFzmn5oToXIbMoFrBgTQqQMFjSSGkI1vbjE9amnnipxnSZoTtMPzWl6ofnMnDndmKK/34riE0IIIYQQIkXIFiIyBjotzpw50/33v//dJsfLHpTjymdVTuk+syoEbmQT57IH57jNW8uldN+iZNCcph+a09LPihFtS3oIIo1R5ToDiW35Hdsy/JdffknL47MIMq9mMEIIIYQQRUXiWqQVxPfFwrKCv//+2+20006uatWqRfZpCSGEEEIkQuJa5AltyJs3b+522GEH6zrYs2dP99tvv0Xer1OnjrUip+kLEXm1atVyEyZMSMlVXbt2rTvnnHOsUUzlypXdwQcf7J544omobY477jhrNnPNNddYF0cysX0F/OWXX3aHH364ZWJzHthCGjduHPX5SZMmuX/961+uUqVKrn79+u7ee++NvLdixQrbz7Rp0yxPm22mTJmifzFCCCGESIjEtUjIV199Zc1cOnXq5BYtWmQiE5HqOyd67rrrLmszvnDhQnfVVVe5bt26uc8//7zIV/bPP/80cUwnxsWLF7vLL7/cXXDBBW7+/PlR2z366KOuYsWKlnN9//33R17v37+/GzFihOVlx7Y0B4TywIED3dChQ20bbhJuvvlm218Y9tOrVy/bJrahDWzevNlWGIcfQgghhMhMtKAxQ3nhhRfMJhFm69atUc/JkD7vvPOsKgwHHnigu/vuu62Ke99991klF4iyQVRDv3793OjRo92cOXNcvXr1inR8Ktb4pD09evRwOTk57qmnnnJNmjSJvM64Ro4cGXm+evVq+zlkyBB30kknJRzDoEGD7Mbg9NNPt+f77befW7p0qXvggQeiGtFw/n6beHCdbrnlloTvCyGEECJzkLjOUFq1amUCOcz777/vzj///Mjzjz/+2CrWYSsE/mW6Ii5fvtzsFBCuCmOj2GuvvdyPP/5Y5OMjtqkmI6a///5781NTJcYiEobqdjyopicCawuV+UsuucRddtllkdfxZpNxmex+4IYbbnC9e/eOPKdyjYVGCCGEEJmHxHWGsuOOO7q6detGvbZy5cqo57/++qu74oorzGcdC95qTziA3QtsBHhRj3/HHXe4sWPHujFjxpjfms9QRY5dtMjriY6RCM4NJk6c6I466qio92Lbree1H8DTzUMIIYQQQuJaJIR24tgkYkXwtgIPdfv27SPVbAT7smXLXIMGDYq87+rVq7saNWpY63SsL0IIIYQQqUDiWiQE/3TTpk1tAeOll15qFVzE9muvvebGjx9f7FcOL/X06dPdu+++66pUqeJGjRrlfvjhh5SIa8AnTVUeGwgLN7GcfPjhh279+vVRNg8hhBBCiGSRuBYJwUs9d+5cd9NNN1kcH37rAw44wHXu3HmbXLUBAwZYZZmEDnzWpIXQfGbDhg0p2T83DOwX+0nfvn3t5gH7iV/AWVQW39La7bLLLi6VkLP90ksvucWDW+ey44iyieY0/dCcCpHZlAtQTEKIlMGCRqrh3AQUl7gmoUXiOj3QnKYfmtP0QvOZOXO6MUV/v1W5FhkDTWGI2yOPO7aZTHGQPSjHlc+KTjYpKlkVAjeyiXPZg3Pc5q3lUrpvUTJoTtMPzalzK0a0LelpEKLEUBOZFHDhhRdaQsaVV16Z673u3bvbe2yTSuJ1G9yWcD6MoTD4Doq//PJLrvfo+Eg6SHFAPB4Z2NnZ2cWyfyGEEEIIiesUCrcnn3zS/fHHH1EdBqdOnRoVWyeKF7Kx48UAEt9HxB4Z3NttV/gvbGJjAIUQQgghwkhcpzC2DoH97LPPRl7jd4T1oYceGrUtqRSkVOy5557W5fDYY491H3zwQa7K7htvvGENTFh0d/TRR0daij/yyCOWdEGTF7bjwWtAoobPhGY8dE70mc4esp15j/127NjRPrPbbrtFVaVZOBiGRX7HHXdcwvO/9957Ld2D8yHm7owzznCpIL/z4bwZ+6xZsyxFhLzpb7/91irgt956q+vSpYv5plgMiS2Ea/Xf//438nnaqrdp08a6RTJu2qv//PPPkfc5Z9JSOP9q1arFbX8uhBBCCOGRuE4hF198sXv44Ycjzx966CF30UUX5dru+uuvd88884x79NFH3YIFCyxHGtG2bt26qO1I6aA9N/FwVFvZP5DW0adPH9ewYUOzOfDwCR7ly5e3FuVLliyx/c+ePduOF86Oxr7Sq1cvE5m0Bx86dGiRzpvxcbNAu3FuAF555RXXokULlwryOx/4/fff3e233+4mTZpk23HTAnfeeadr1KiReaxvvvnmXPvGlnL88cfbzQ/nwLiJ+jvrrLOituO4FStWtGt3//3359oPN0ssggg/hBBCCJGZaEFjCqHZCa2wv/nmG3uOGMMqQiU63Habtt9UXKmY+koy2dEPPvigRcJ5EL0tW7a03/v37+/atm1rVpMddtjBKq0IbmwOYcIxclRvb7vtNhPTVJZh3LhxdtzrrrvOnh900EGWI/3CCy8U6Fx9pRyoFFNZPu2009zOO+/sateunataH4+aNWvmeg2hXJDz8at+eY6QDoNw5ibEQ+U6DFndjJMW6+EbIirkNKvh2gAV+ZEjRyY8j+HDh9s3CUIIIYQQhRLX3333nX297sXR/PnzzVvM1/J8/Z6p7LHHHiaAEZ4kHPI7VoIwX331lYnBY445JvIaMTBNmjRxn376aa6cac/ee+9tP3/88cc8Pdyvv/66ib3PPvvMKqh///23CXJEKzYQKstYQcJw7IKK6zBUvxHU+++/vzVj4cExOF5evPXWWybGw8RaT/I7H6CqHL5WHiw1eYGtZs6cOXajEgvz5MX14Ycfnud+uKEKN51hnAh0IYQQQmQehbKFnHvuuSZKYM2aNSauENjYGLAGZDJYNxDXWAm8jaOwhLMXuZmBeIv1wpVZqscITWwnH330kbvnnnsKvBAPK0Zs/Dk3BIlAIGNveeKJJ+wmYODAgVZFjpcGEoZYPCwx4Ud4sWGy50Ml31+fMFTT8wLv9r///W+zx4QfX3zxRZStJb/94PPG1x1+CCGEECIzKZS4ZhEY1U546qmnLNoMa8GUKVOi7AKZCFVbhB9iNN7iNzocev+uh21Z0FiQtt7sg2SMMIhPxDc+bdqWU3ldtWpV1Db16tWLWjwJsc+pwOPjDhNeBBgPRPGJJ55o9olFixaZMMYfXRSSOZ+iLkLFo43dJFbk5yeohRBCCCFSJq4Rg1Tr/Nf27dq1s9/r16+fS5RlGsS9Ye9YunSp/R4Loq1bt27mrWYBHdtddtllZnO45JJLkj4OgnD58uUmekm3YFEdopC5wVdN2/DHHnss1wK8Hj16WFciUjio0D7wwAPu5Zdfjqr84lVmgd/kyZNtm0GDBtkNVSKwlLDokLHgN+dziGKEfFFI5nyKAhnkLCI955xz7AYDK0hOTo4tQo29cRFCCCGEKDbPNSkViBw8xSzEI/IMqCpWrVrVZTr52QJGjBhh4pPYt02bNpk3GFFXpUqVpI/RqVMni/pr1aqV2S9IKSFCD9FMcgY+YKwN+JWJo/Pg9WbuWIA3YMAAq65fe+21trjPw2uka5DKgb8Zewv7+OSTT+KOhSg8xkJTGbZnASAWEf6dFAWsJfmdT1GoUaOGfYPQr18/d/LJJ9sNCt5xvn3AGlNUFt/Sutjany8e3Frtz9MEzWn6oTkVIrMpF8Saa5OA9AsWrLFwq2vXrpawADfeeKMtPAtnPYvSD5Vz5o0FhqLo8N/Frrvu6jZs2FBs4vrUU0+VuE4TNKfph+Y0vdB8Zs6cbkzR3+9CVa5JdMCKwCDC1VaSQvJLiBAlD/nPLELFooIlhMWX4Wg7IYQQQgixjXOuKXiz4AyfKukhJEawyE7iuvRDsgsLD7GkEJ+HX/rSSy9NeCPVuHFjN2bMGFdawX9OHnY4E7s0kD0ox5XPSu3NZlaFwI1s4lz24By3eWvuhBRR9tCcph8lOacrRrTdpscTQqRIXLNoDV8qzUPwqVIFRVzjjeV5KhedpRN4oqkSA19DkFeNfxg7TTiCrrgh4SVZsPiEvzIpDkgWIZYvlvPOO889/vjjxXpsIYQQQohUUihFR+tsFuHRhCO8gBEfNv5dkRhuSlh8yE0Ifh8SKxCvLNgrKCRakPKRisV3sRAnyDcRu+++u9tWkDwTXgRJfrUQQgghRFmiUKqMhW8kTSC+Yr+e//7771M1trSECENalpNKQSQf2dCzZs2y9xDctCXfZ599zA991FFHRbVOJ0OcZA62JxObfflvD/L6nG+xTtdAbDvcBJHCwb48JH1g/5g0aZJVkStVqhSxhcS2IKddOAkifFtB9X3ChAm5OnieddZZtn/Eefv27XO1Ho8HN2pcG/9gUQG2Iz5fvXp166R45JFHmgjPC9JTrrjiCvsM50EOe7gDJQ1pEPFcP86HHO0wyZyjEEIIIUTKxDUxcvFygFeuXJmrnbXIG6qzvtvg1Vdf7ebNm+eefPJJa8Ry5plnWqWbrGkPedjYbxDBNEDZc8898/0ccXNXXnmlfeNAFjU2nqFDh+Yay5dffmnCEytIXk1jEKN8c7Fw4UJ31VVX2U0CbdXBN8/h3wE3YRwbUeyb6xQUuiiymveNN96w47EfuipyU5Ho32abNm3suFhKyBEn+tBnjrNOAOF/9tlnW7QgNxXEDsY2P8rrHGPh5obFveGHEEIIITKTQtlCyARmgZuv5mFNQATRbAQhJJJbEIpgJN+axi6IRewi/CR/GahG02iG16mkevFKsgcZ0JDM52jCguDkdaDTIR01w9VcQPzSAIYOjXnBHCM4gYzo0aNHuzlz5ljTmGnTppnARfz7xjSMgyo21XT+7STi6KOPjrK4IM4PPfTQyLkCmeozZsyw6j03FbFQ1WbBJo18OE9g0aaHiv0JJ5xggtpfCwT4HXfcYZ74ZM4xFrK3yQ0XQgghhCiUuKaqR3USawJNQ0gLoUparVo1ax4iEoOgpZKLSEaEcu2oniI8+TbAC8JwVTTsa8eKc8ghh0SeU33N73NUXLGChKF9fay4xqqSn7CG8PER0Fg4fvzxR3uOD58KeOw3GPw7weKRFwjzf/3rX5Hn2Fi4aeP6vPjii9b98++//3Z//PFHwso1FfeaNWvmuh4eRDc2kzA01uFmkevoK9x5nWMs+OV79+4deU7lmrELIYQQIvMolLhGvCCivA0BAUTrbtIdtAgtb+ioeN9995lIptLsU0K4hgg7bAuxbdMR4x6ub7hVebKfSwb82skQmx7CeLhR8OM5/PDD3ZQpU3J9Lj/hjiCl5XkYrCx0ASWbm/c4/zPOOCOhxSRV//7yOsdY8G7zEEIIIYQodP4bovD888/XFSwgCNhYAQnYH6icUh1t3rx50vtL5nNYGT744IOo12Kfp4rDDjvMKtB4wVPRnRDvNHYNX3lHvOe1OJKKM97/ZcuWxa1eUxlnn7HHYNvYmxMhhBBCiGIT13hc8e1S0fPpFolo165dgQeS6SDuqPyTe43tBtH8008/mS8bwdi2bdtCfw5Pd4sWLcxvzGLA2bNnW2fGcAU8VTAW/MtYL4YMGWLfcpCLziLJ66+/3p4XhAMPPNA+y7gZL17pRBVkaNmypZ1rp06d7Hy5kaG1O59lMWSfPn0scQTvdufOnW0h6Pjx49WhUgghhBDbVlx36NDBrVmzxiqS/J4IREy8JBGRPyz8u+2220wAEmmIh71p06butNNOK9Ln8BTT2IdFd0Qo4pe/9tprTVSmGqL+3nzzTVsEePrpp1sXSCICWURYmEo2AplIPBY7cl7sN780DhJPWLx5zjnnuN9++80ENokhvrJOE52BAweawN57773tJiC8mDFVLL6ldUqq92Hw6pOPvnhw62Jv7iO2DZrT9ENzKkRmUy4gtkJkHDT7oaJLIodILYh/Mro3bNhQbOKaNBOJ6/RAc5p+aE7TC81n5szpxhT9/d52PbfFNoPGLzSEIQHDw4JA8q3xfGMJoQ07kX5l9XyKG76BIfIvr29p8iN7UI4rn1U5pePKqhC4kU2cyx6c4zZvTb2tR2x7NKfpx7ac0xUj4lsGhRBlrIlMz5493d13353rdWwG4W5+6Qw2AgRY7ANfb0mDRxnLQxiynxHXBx98sFlEmL9LL720yMci+xn7CUkgdEM84IADzMuMNUQIIYQQItMoVOUaT2u8RY34YvG2bssKY0mCkMbvHKYokWw4dPCr+3i+wkLL8VjwGacaKt80crngggssIQRhzVcpCG483cQDCiGEEEJkEoWqXK9du9Y8KbHgT/n5559dpoCQprlI+FGlShV7j7g4KtnhNuK//PKLvUbDGOAnz7FpkA3N/t5++21rtkLaRvXq1S2rmnQLOg/GCluSNKgWsx3Zz2EbRfgbhMcee8xaedPYhTHSuCbcEMWPg4QRtmNRIjdKidp9A01cOAYPLCbHH3+8NaEhoYRs6g8//DDXDVnDhg3tHOvUqWPJJsmeD5AQQtoINw6cA41lYhc+UpXH9kJeNt0Vie3zNy1U1qdPnx7ZHpsJixk9XHfGRnv5eNB9lO3JdRdCCCGESKm4Jn2B9tqxIBLDraZFcvTv398q/nQPRJwiCjHZI3YXLlxoFXKi6HxXQoQr1hxSLhDAzAXxc3kZ97GJ0Phn5syZJvzjpWPcdNNNJnrZP9VzUjoSgVhmvwjeeIRj/qhgn3XWWe7ss8+2jpIIYyL1HnnkkaTPBwGPcH7//ffdyJEjbVuay3hom47VZcmSJbYtcYN+bIyF/fmbmvXr19u1ptMjizph7ty5dhPDjUUYhDlRhrSFZ/FnuHNjuBsmiyDCDyGEEEJkJoXyH9DqGTsAecpULAEhiDDLFEtIuJV5mBtvvNEeBQGhiB/aQ3W2UaNGkecIYxbXYcXhuiOyEZp4nalGUzEm3zoRYZHMzQ8iFCGJiA+Pf+jQoZYT7QU/Gdm0LaeaHAtNWvimgipyWHB37do18pwMaarJVJWJ4kNQ+2zupUuXWh42Ij+Z80HUUj0GKtz4+/k3569buFJPZZxowiuvvDKyaJNq/gMPPGC/4wdn/4wdwV2/fn376c/dQ6t1GiVxg0Nlm0jBeAwfPtxiDoUQQgghClW5RqwhpB988EFr583j8ccft7beRLxlCpw3to/wA0FXULBihEH0ktNMN8HddtvNBDCVVl+5RlAiQBHK+J1pNZ7IzuArx1S+a9WqZeLVi0i/P0+4KustE2H7SCyxTWjIz+YavPjii5Yv7fPOGTtZ22F4/sUXX9g2yZxPbMWY8YXHhm0GAY8A5hzZD/Ylvx/OGUHPDSFVasQ2D0Q1Ffh3333XnofBN06lHDGeSFjDDTfcYF5z//juu+8SbiuEEEKI9KZQ4hq6detmbaZ/+OEH+xr866+/ti6BmdjKPPzwiwmxKUA4RhwRl2g/YRDWVKqHDRtmVgQEKxXgLVu22PuIxwULFrgnnnjCRCYNUah04+mOBZGL6KXKjGil7Tn7Br8/Tzjr0QvnRN0QqR4jJGks5OEmgGuAUC4IyZxPbKYz4/Njw+ZC1RsBTvWcm4l77rkn6hy5fswNwjosrvmda8Lc4DMPg+inKU9OTk6e48erzfUNP4QQQgiRmRRaXPOVOdVCYt+8gFy1alVkEVmmwwI6WL16deS18OLGvHjnnXfMLtGxY0cThdgXEJBh8ESfeOKJ5j9mkR3v4zOOBU8xFVw83c2bNzcLRF7V6GRhwSGC9/bbb893WyrwnFPsOWIPqVChQoHOJx6IaYQ236bQmZL98m8xVoxz/s8995z5so899lgT4/ilsYvw7UHsTU67du3c1KlTLbLwySefTGosQgghhMhsCuW5/uabb2yRHbYCxAkVPqqPCC2ek6OcCXCu4cqtF4m06d5hhx1M6CFq99tvPxO0tB5PBqrC3LRg5UAU4lUOV5DxevNNAYv0SCehyxDv16tXL9e+sIJUrFjRjRs3ziwrixcvzpWBXRjYL2KWZJB169bZzQDnye9YhMALZ9qy4/HmuGRg48XGM+390AU5n3hQLafyzDlyzRDu8f4NUqlmLAhp7zXnmFT0+/btG3ff3OCQtoLNhLmNTTERQgghhIgiKATt27cPzj///GDz5s3BTjvtFHz11Vf2+pw5c4K6desGmUDXrl0p1+d61KtXL7LN0qVLg2bNmgU77LBD0Lhx4+DVV1+1bbhOwE+er1+/Pmrfy5cvD1q1amWf23fffYPx48cHLVu2DHr16mXvv/XWW/a8SpUqts0hhxwSTJs2LfL58LYwderUoE6dOkFWVpaNZ9asWXbchQsXJhwH7/EaY8mL1157LWjTpk2w++67B9ttt11QvXr1oEOHDsErr7wStd306dODBg0aBNtvv31Qq1at4I477oi8V9Dz8f8GmQPPqFGjgr333ts+37p162Dy5MkJz6lfv36R10aPHm2vxY6X12bMmBF5zngqVaoUPPPMM0F+bNiwwT7Pz1SzZcuWYObMmfZTpAea0/RDc5peaD4zZ043pOjvdzn+xxWQqlWr2gIwKotUrIl4YzEaX+U3aNAgz8V1QqQ7rEEgBx5Peqr911ToqewT1RjrQxdlE81p+qE5TS80n5kzpxtT9Pe7UJ5rvrL3SRBhWOCI2BZCCCGEECITKZTn+uSTT7Y86wkTJthzfMEsZCSHmLuAkoJxkITRoUMHlwnwTQE+Z3KY6ThYkuBnZgxlMeecpjY010l2wWmyZA/KceWzopvSFJWsCoEb2cS57ME5bvPW6ChEUTbRnKYfxTGnK0a0Tcl+hBDFT6Eq1yxkY9EYFhCajNBOm8YdxJYlkx5RGMgnJv6PhXS+7TgRc7EpFMUp3BFg+cHCvtIk7pcvX27zU6NGDWsGU7NmTWut7jsTlma4llz32AeLaYUQQggh0qZyjUDDZ008GbFpVK0vueQSd95551lKRnHQqVMnyyymtTX+bvK16dBHzFxxwjFJ2yirniKSXPDGkz5ChjTWHdrUx8vELo0gpB9++OGo17i5EkIIIYRIq5xrYsloDU0uMZFqZAEXl7BGCNJMhao4XRFpUtKkSRPrjEcWcZiff/7Z4tMqV65skXa0DA9D0xA+i0BDbNLmm8zusL2BFuO00yZSj+o4VXlgv1RO/fN49gLEP1nKvspKB0D45JNPrFU814gFoZdffnmuTPBJkyZZJjQVZvKofVSdZ/78+da2m/eJk8MOkhfkOX/11Ve2H2IBuW50RqQ1OM+9tYRxIr65tlw3GrgQl+fhBuacc86xLoW8T/Y2DV/ygi6NLAog5g7oWnjWWWdZx0mauVA9j83ujof/liL8IK7PQ2t1xkNG9b777uuuuuqqXNd14sSJ9h5jZw75DOPIi/zmQgghhBAipeL6888/NxFKy2ke/F5cVgMyiXlgyyBbOi9uueUWE3FU1PF/U00nexmwrfAamctU3mnXTgt3xGYYBDLVap+XTAc/oIJKUxj/PBY6K3Jsqq1sx4Ouf75LIqKQzz799NPWgIdr5kGE0plw6NCh1i6c7ozkWzMWQDDShRArDk1TEPIcL79GNnSKnD59etwFqGFuuukm2x++Y5qwIKb9TQfWn8MPP9wEMznZ3BiQ+4zYjweNV/g858T1p4LO+bPYlZskrivzyXWK7RJZUDi/u+++224kuFY0nrn++usj73Ms8r3J4+bcqORzjfMiv7mIhX+TrDAOP4QQQgiRmRRKXNNiOjs720QeVU4etK+mgsh7qYYq+SOPPGLihooj1dcbb7zRBHQ8ny7CjsYiiCJEqReBVB+pYNLAhGok3mjEOB7ycJMWKt5U5LFT8PDdFjk2lVP/PBYEI5XpcLUVkY7YRKBOnjzZrhsVbMZAcxLsLcBiUMZx+umn2yJFfl577bXWPRDYB2PkZqBhw4YmtBM1PvFQaUZ4IhQR9hyXRi40bIkFYd22bVsT1lwTGgV9+eWXkf3wPgsWseT06NHDhPFTTz2Vaz+0Had6/Pzzz9sYYdq0aTZ2qsH8G6EizI0KTYh8ZT8RNJjxN1f+wbx6+IaBijvfJnB+3CiFx0VjmTZt2tj4OTfGxvO8yG8uYhk+fLhV6f2Df2NCCCGEyEwKJa6pDGLJwDrAV+w8yL1G8Iarhqn2XNPSGpsHwg5Rdthhh5noDkNLaw9WAXIKfbtvqpDNmjUzG4QHoY4Ax4vsoUqbHwjDRIIvFo7LDUi4vTbHRXDyDQCVbewb+NbD+0Qo8rrfB+eGTcHDueRH9+7drYsk1Vi2p2qOOH/ttdcSXjfsMuCvG1VvRDnCGEsHY8vJybFrEIYKOSKUfbds2TLyOt8SINSpXPtzYz/ccHB+VLPD5+2tJIBwpuIcflCJ9vANAN+ccAPA/qmoY2PxWetcX2xAYWKfh0lmLmLhvwUyMf0DC4wQQgghMpNCLWjE7tClS5dcr+PBvuOOO1xxgbDka30efE2Pz5sqI9VqT2xjDYR0uCqdDGERnAjSN8LRbYjFwuI9wniDjzrqqKj3fAvxooDopC04D0QiFg1+ch3jXTd/8+GvG3M6duxYi9nz/mYqxrGWDvzgfIPx0EMPmSfc74fz44YlLJo9fAtAdT98LatXrx75nWPxLUQ88GxTHSdFBgsHc/D222+bMGZseKy3xVzwTYUWWQohhBCi0OKaRX9UG2NFD8KmefPm2+zK4j9OJh7Pgx0B2wpNKb3ww5OL+CQBJS8Qn2HfMlaVeKIPoRjrb+a4VNipinrhznHxC2M7QUwi1rFr4FFONHZsJFR7ffX6vffecwWF88YSwzcNycJYWYDIzZMX3cuWLbPrH+aAAw4wOwX/PhCiWF+Abxiwhuy5554JOx4lEtB5gS2JsXBMriXEWlW4vrEe+USeeUhmLoQQQgghUmoLIaGjX79+tiDv8ccftwe/k7xBGgPWDf9IBXzNj5+W4+CzJrsZewO+aERfsuC35St7PMMsviTVg8p37969I+IsEXh6if7DYrF+/fo8t2OM2BFILmExHyINQdy1a1dbEDhnzhwbAxYGX6XF54x3F480wpV0EXzJWG6ArGqE8WWXXeaWLl1qbTvvvPPOPMdMNZjrg12Dz2DNwLNNZbkg1w0POlYPBDn2lCuuuCLiFY8FXzPnx00M1W3g/Ele4ZjclDF/2Hp69uwZZcdJtFiQax5+cF29IOf64qtGDHPzwQLUMFxnrhXX8YsvvjDfNFGEYWtQLPnNhRBCCCFEQoJCUK5cuaQe5cuXD1LBn3/+GfTv3z847LDDgl133TWoXLlyUK9evWDAgAHB77//HtmO05kxY0bUZ9n+4Ycfjjz/z3/+Exx55JFBxYoVg7322ivo169f8Ndff0Xeb9myZdCrV69cY5g1a1ZQt27dYLvttgtq166dcKw//vhjcNJJJwU77bSTjWfOnDn2+qJFi4JWrVoFlSpVCnbffffgsssuCzZt2hT12SlTpgSNGze2sVWpUiVo0aJF8Oyzz0benzdvXtCoUSN7n+2eeeYZO8bChQvjjuWnn34KevbsGWRnZ9t4dt555+Dggw8O7rzzzmDr1q22zfLly3PtY/369VFjX7t2bdC+fXvbx5577mnXvUuXLvZaouu2dOlS27Z37972fPXq1faZatWqBVlZWcH+++9v12DDhg0Jr2XXrl1tHLEP5t4zatSoYO+99w522GGHoHXr1sHkyZNtG87BM2HChGCfffaxbTp06BDcdtttNveeQYMG2XUtyFzkBefEGPI6t8KyZcuWYObMmfZTpAea0/RDc5peaD4zZ043pOjvdzn+J7H0FiL9oPrPNxdU0YsDovhIDWFxYyIbTGGhUk8lnkjJ2PUFomyiOU0/NKfpheYz/Ug0p6n6+10gzzXpIFg0fMQaEC+HtQI/MdF2fEWvxV1lF/Kz8bGHFxjGwgJSGvsUxO9ekmCfYfEmfncsIUQ6hpvCYOXBwuJtLKkie1COK59V8EWVeZFVIXAjmziXPTjHbd6a2Noiyg6a0/SdUyFEZlIgz/WQIUOsWYcHLyrJDCeeeKL5rck2xqsqtj14kWmUgg8ZfzdebuL+aJTjY+nKGr7LZezjySefLNB+yDlHXJN0gicbLzVJM0IIIYQQqaZAlWuqmeQdexA5xJURWwY0z6CKTfVTbDtYzIeQpskNeduISL494OZnwoQJlgEd2ya+rMBCQnLNw+TXujyWeM1uhBBCCCFKvHJNSkY4g3ju3LlR3e5oK64GGtseUlCIBvzwww+t/TqxfXRSJJ2DluXkW3to/MLrNEbBT8T2iZI/gFhB0lQQtFWrVrUmQbE2feLw+MaCboZ0qKRhDgklHpJBqDiTtkL+NfnTtIUnUSU/fFfM8MNHEWJRohsnNw/sk5uKJ554IurzmzZtsrQSLCE0xxk9erRFBeZlAcHyQmWbDG6uEUk1NMIRQgghhEipuEZYE6MGNOmgYUjTpk2jhIwWWW1bEJivvvqqdWJM1Pwm3BQGYb1u3Tq7MSJej6p3586dE+6fDGkyuonvI8ecz86YMSNqG4Q13nssF9iG6NJIJjbHCHPTTTfZ/rgJ4Gbg4osvLtK5k/lNcxpuIIg4vPzyyy3e0Le7B24MyOkmFpLzZREj/27z4swzz7TulPizydImp5sukJx7orhAFkGEH0IIIYTITApkC2FVJd7q22+/3RazUS0MN40h35lGImLbQXY1lWSapYQhVxrxCQhv5ozKMVYRbpCw8ACimHboNFbhm4dY6MpIe+/TTz/dniOgaX0eFpZYUWhD7tuxUzVHiJMpHW6DThdF/5x/R23bto1qihMPKtOxnRHJ7K5Vq5ZVrK+77rqoTGvGhg2EFufc7LF4cerUqSaOvc2EJjGJYNyIc8S1X5jLgkj+vVONR8DHws0F2dhCCCGEEAUS1/itEVkIJGwFCBc6Enqobp588sm6qqUABCKVaiwRCGCgAQyi2gtroMsi1gveixXXRNHQ6j7cBpyKM9YObw1B3LNgMtxK3X+zQTv0MIccckjkdywagIhFKCcCGwcLZsN4cYxlBWGPmP7+++/tmJyrb3tOVZ64HYS2h4id2BuRMNg/aIGOBSbMH3/84b766qu4n+Hmgwq5h8p1+BoLIYQQInMokLimGvrmm2+a6EJcx1YU6ZrI62LbQToIto9Y/zLVY8ADXZwgRAFrBpXkMLGRjGHLUNiqkhd4rBO1Rr/jjjvc2LFjrbqO3xpbDF5qRHZRzgfhj088lkQLKTlPxU8KIYQQotDtz6n+xQpr2H333aMq2aL4ocJK1Xj8+PGWNZ4XLHRkwWl40SkWCxbwUcGON88Izffffz/y2t9//20+ZA+fQ1iyUBIRHH4Ud/UWLzUecvzdLKLkhoJ25R6eI+ixvHi4MQxvEwv+amINqdDHng83l0IIIYQQKatci9IJDVGI4sOuQQwi9ovy5cubqKQTIYv+AHsFFV6sIlR7EcokjWDz4bPxIDt7xIgR7sADD3T169d3o0aNMjHu2Xnnnc33zCJGqtDHHnusCViEL0kbXbt2LdK5cSzEbhiOSZWaMeGDfvfdd12VKlVsbCSf+BsFtuP4ffv2tRu/Pffc06IiuTa+ch4L1wjvOA2RRo4c6Q466CC3atUqq8x37Ngx4XUSQgghhACJ6zSARaQLFy40/zH+35UrV1o1GZGJ8EVAA4Lyueees4V/LVq0MJFJhjRdNRPRp08f810jUtmehA9EJgI67MUnto6FfficsU9QAb7xxhuLfG4XXXRRrtc4DgsiBwwYYMdr3bq1+axZbIgoDo8NwX3llVdaV1HEPlGCVO4TLaLkGtESlWQTjv3TTz+ZNYXrFY6hTIbFt7Qutvbniwe3VjJPmqA5Td85FUJkJuWC2NBiIdIYrDN4w4kEpLtoccCCRiw1iPziEtck9yj2Mj3QnKYfmtP0QvOZOXO6MUV/v1W5FmkNFX2sMSSG8B/LkCFD7HW82kIIIYQQqUbiWkRBwxgSN7yvGg83Gc///e9/7fmFF15o7/FaIuiA2LhxY/N1lwbIqSZNBcsHaSBkWW+LxYnZg3Jc+az/xQKmiqwKgRvZxLnswTlu89b4vnFRtsj0OV0xom1JD0EIIUo+LUSUXhC/iEgeJLeQckG1lsWLqYDoOwR4UeDziWLtGHdewr2gkLVNugmimm6W+MdpvS6EEEIIURyocp2GsEiRToQ0VMFTRIdGPEUsdiwqeJFKM2Rcx4uDxF/F6yxOLI79CyGEEEKAKtdpCEkhiMjatWu7bt26WbzcrFmzIukZvuEKOdQkifhGMMlWxknkCC8Q7NKlizUPIhObhYKppF+/fhaHRxoIudU333yzCWUPthUsKJMmTXL77bdfJAWECvh9993n2rVrZ+dK63Uaw/B6OEoQi0jz5s2t2Q7Xo2fPnlF54XXq1LE0FM6RxQ3x2p8LIYQQQngkrjMAhKPvWkic3t133+2WLFli7etnz55t8XSFhQzpuXPnWsTfq6++agJ2wYIFKRs7WdXYSGh2gyVl4sSJ1hI9DC3Yn3nmGffss89GvOFeeBMb+Mknn1iEYCy0M6fK36lTJ7do0SI3bdo0E9tXX311Ls82TWpYHIm4j4VvCFhhHH4IIYQQIjORLSSNIWXxjTfecDk5OZZtDSxWDFdlb7vtNsuBphFNQaHi/eCDD7rHH3/cnXDCCfYagr1mzZr5fpbkDqrd+UGWdXi85HY/+eSTUTcE3DhMnjzZsrbDnHvuuVE52WRix+Zl01DHXxOa0nDjQVMdqt6+Cn788cdb3nci2M8tt9yS77kIIYQQIv2RuE5DXnjhBROu2CfomojIpIoLr7/+uolB4umosLLQ8c8//3S///67WS8KApVfhO1RRx0VeY1OiPXq1UuqIh2vwo3ADUM1GcHLsRDzjDc2exL7S6ywhvy6KX788cdWsZ4yZUrUDQnXbPny5dYuPpn94GXv3bt35DnXtbhbvwshhBCidCJxnYa0atXKKq8svKtRo4bbbrv/TfOKFSusUyE+bDzICGFsEDRTQSQXVFwXBewpJJnkxbx586yyTFWYLowspqRqHevrxlMdj0SvexDrV1xxhfmsY6lVq1bS+8HjzkMIIYQQQuI6DUEMxhOuRNJRlUWcIm7hqaeeKlLbdVJI3n///YgYXb9+vVu2bJlZK4rKu+++a1VpWpF7vvnmG5cqaNGOlzs/kS+EEEIIkSxa0JhBICKxiowbN878x4899pi7//77C70/rCdUvVnUyMLIxYsXW5qIF+5FBYvIt99+a9VqbCHYQ2bMmOFSmUSCgGcBIwshv/jiC1uYGbugUQghhBAiWVS5ziBIvCCK7/bbbzefcIsWLcx/TcxcYbnjjjvMXvHvf//bfNQs/GOxYiogRu/aa681sUsiR9u2bS2tw/vHi8ohhxxiSSdUxonjw29NNb5z584p2f/iW1rn8ocXFW6OyC5fPLi1fWsgyj6aUyGESC/KBSgKIUTKYEEj/nBuMopLXJ966qkS12mC5jT90JymF5rPzJnTjSn6+63KtSgRWFxJ0xeyo2kCU5JgZaGxTCrbrkP2oBxXPiu1i0SzKgRuZBPnsgfnuM1by6V036JkyJQ5XTGibUkPQQghtgnyXKcBiEM6D/pH1apVrTkKMXOpFsTsP9yopTg57rjjos7LP8jlFkIIIYQojUhcpwmI6dWrV9uDxjHE7xG7V9a57LLLIuflHyNHjizpYQkhhBBCxEXiOk0gZ3mvvfayBzaL/v37u++++8799NNPkW1oA063QdqhU92+/PLLbTGih5i+IUOGWIdF9sd+Xnnllcj72Djg0EMPtQoylWXPpEmTrOkKXQ3r16+fq+Pj/Pnz7XO8T1MW7CDJQPa2Py//CPugSPw46KCDbLv999/fFjzipQpDF8o999zTFlxeeumldm3ysqJwHVjoyflyrVgIOn369KTGK4QQQojMRp7rNATBTEtyovcQ0fDbb79ZI5ZmzZq5Dz74wP34448mNEnieOSRR2ybsWPHWgb2Aw88YEL4oYcessSOJUuWWCweArlJkybW5bFhw4bWpAbocDhw4EA3fvx4+xzCmYozedtdu3a18VBFP+mkk2xcdD/s1atXSs4Vwcz4aZbDzQPH5TXfHp2x0TAHsX/MMcdEmtD4G4V4IKwZJzGFnPebb77pzj//fOsCGS+/myQTHuEFEUIIIYTITCSu06zluRfSe++9t73mM6enTp1qbc4nT54c6TiIGCZCj2i+6tWruzvvvNMqwWeffba9z+tz5sxxY8aMcffcc0+kxTiCnQqyZ9CgQSZYTz/9dHuOcKU5CyIdcc2xqQY/+OCDVrlGmK9cudI6ReYHopiqeBj2S+dGGDBgQOT1OnXquOuuu84EtBfXZHqTxX3RRRfZc24CXn311aiKfRhE8rBhw+wGghsRoCJOJ0uOG09cI8bpIimEEEIIIXGdZi3PfZdERGmbNm2s2kyXw08//dTsDeFW3lRyEb2ff/652R9WrVplr4Xh+ccff5zwuAh5GrwgYKkae/7++2+LswGOTaY0wtrjhWt+IKLDHRqBGwHPtGnTrLkMY0Awc9ywbYRzu+qqq6I+T/Wdpjfx+PLLL93vv/9uVfYwtIenKh8PMsN79+4dVbned999kzo/IYQQQqQXEtdp2vKcai/iduLEieY5Li58BZjjHHXUUVHvVahQocj75xwStSefN2+eiW+qxlhe2NbbPop6Pi+++KLbZ599ot7Dhx4PXk/0nhBCCCEyC4nrNIUFh1hC/vjjD3vOYkO8yVSaffX6nXfesW3q1atn1V58y7wWtj7wnEoveI/11q1bo6rIfI526t6qEQvHptU6thRfvX7vvfeKfI60LqcqH65sf/PNN1HbcG54zMNdKHmeiAYNGphQpu16PAuIEEIIIUReSFynCXiF16xZE7GF4Kf2bckB4Ys3Gg807cNJEenRo4e74IILIjaLvn372ja0ACdN4+GHH7ZMaxYFAokb2EdIECFRBKFMtZjKcc+ePe13IgEZy4cffmjjwC5x7rnnmgDGNoKFgrxs/N3JgEXDn5cH8VulShVbbIgIplp95JFHWrV5xowZUdtyjhyXhJKjjz7abCTkf+OjjgeLIfFt03Ydy8yxxx5rnZq4yeAGhOsnhBBCCJEQ2p+Lsk3Xrl1pYR957LzzzsGRRx4ZTJ8+PWq7RYsWBa1atQoqVaoU7L777sFll10WbNq0KfL+1q1bg8GDBwf77LNPsP322weNGjUKXn755ah9TJw4Mdh3332D8uXLBy1btoy8PmXKlKBx48ZBxYoVgypVqgQtWrQInn322cj78+bNs/3xPts988wzNtaFCxcmPC/2Hz4v/2jdunVkm759+wZVq1YNdtppp6Bz587B6NGjg1133TVqP0OGDAmqVatm21x88cVBz549g6ZNm0Zdv/bt20ee//PPP8GYMWOCevXq2XXYY4897Jhz585Naj42bNhg4+RnqtmyZUswc+ZM+ynSA81p+qE5TS80n5kzpxtS9Pe7HP+TWHoLkX6wWJG0E6wqxQELGqniU/EOL65MBWR4v/TSS+7UU09122+/fUr3LUoGzWn6oTlNLzSfmTOnG1P091u2EJHWYCshr5oFjyywfOKJJyxm77XXXivpoQkhhBAiDZG4FiXGhRde6H755Rc3c+bMYl3Yyd0pjWRYUMkCx2eeecadeOKJkW3wgJPNTfObvDo3FpTsQTmufFZll0qyKgRuZBPnsgfnuM1by6V036JkKK1zumJE25IeghBClEnSrv05i9/o/kd8GwvuWKxHVjMZ0FQxixsSOXbbbbdiPQaL9po2bWpfXbAAj6Ys11xzTUqPgeBEmLKgMVYQd+jQwW0L/vOf/9gY4j1iFzkmggWYVKrXrl1rSSkLFiyINLsRQgghhEg1aVW5Jg4OIY24pcvewQcfbMkStMWeMGGC5RbTzjuR/6Y0eViJu/NxemHeeOMN17lzZ6vEci5sQzfEdLY50Agm1vtEcokQQgghRGkjrSrXdOLbbrvtLAburLPOsnxlItfat29vMW0+lg4QpVSzEajkPiNW4bnnnnOHHXaYVb35LDFzdP3zjBo1ykQ7n6ELH8f0jUeotNJmGyO8r7ASewfE0xHxhsDnszRcYfvYivesWbOispZjef755+0Ggtg8LA4HHXSQVZJpT+7hmNgbaNfNGCtXrmzXg3F5iJkbMmSIRepxLLYnYs+DTQLoSsh5HHfccbbfRx991K6RPz9/Dt99950dg3PYfffd7ZpT/Q7fLBDLx/u0T6c9ebJraRHSLEAMP/xNB5nVLFCsVq2aVfLJpqY6Heazzz6zSD3mlGtLJZux52VHWbx4sXW4pKU8334QWfjzzz8nNV4hhBBCZC5pI6752v/VV1913bt3j2rxHQZBFQax2LFjR6tsX3zxxe6tt96yZiPYSqgGI04RvV54A6KOdttLliwxoUkbbYQikKM8ZswYq7KuXr3aHghquPrqq62jIJnM5CyfeeaZlgn9xRdfRPaNbeX222+37orsP151FmHJe4i/vKCN91NPPWViHNGMnzjcBnzs2LHWyZC8acbDgj9uNPx4aJsOCFHO49lnn7VzQUAzbn9+nDNVfz6PRYVrSCY0opTtaBsOHItr+dBDD7m3337brVu3LlcmdWHYtGmTZU+zTxrTkH3N6l9e96Kemw9uMN5//337BiO2nXos+MCPP/54u7HgRo3r98MPP9i5x4MbJ1YYhx9CCCGEyEzSxhaCmKQSSjU3DBVNFrIBwhvx6qG5CZVmDwK7f//+kUYhVK5vvfVWE880V4Gwt7lOnTrWWvzKK6909957r3UwpHqKiEcEe6hA05CFn3QzBIQqoo3XsbAAIpX9NGrUKOF50hQFAUv1nO6EeK9PPvlkaxITbsHNOU+ePDnSwnvcuHGubdu2JnIZG6K6X79+7uyzz7b3uS5z5syxmwOq4HvssYe9TpU5fC54mBGT4dcef/xxq4RzU+BvYDgvqtRUthkf+6WBjPc7k+CRk5OT1NxSXQ/DeXODAYjgMIhnjjt37lx32mmnmV3mq6++snH4MXOzRLU7ETTgQVj7eQFuCvgWYNmyZfZtQZjhw4fbNxxCCCGEEGkjrhNBBRbhh/hEFIaha1+Yjz/+2Kqu4Uo1lU+EKlVlqp9UchFTWA2oUGIZCb8fDyrj7CdWlDEexKsHcX7IIYfkeT5U5bG4IBgRw1Rr+/TpY5VoKuN+DLVq1YoIa2jWrJldB/zLbLNq1Sqzl4ThOdegoPAZbm6oXIfhujBO7ChUubHCeLDvcP2TsYZwMxHed9gbT0V5wIABJp5//PFHu87MhbfUcL6I4vDNgG/nntf5cG2pvsfC+cTOIzcNWF48/LvgmEIIIYTIPNJGXJMOQtUUMRXGt7mm4hpLrH0E7zQVyHhpEvh18RBTDe3WrZsJcLzF2BEuueQSsz8kEtfsl4zljz76yH6GCQs4xhhrXUkELcp5XHrppWZzQPDR2jtcid9WcH6HH354pE16GF8BLwr4vxMlsPAtA5Ygbi6oaFO950bC21EKg28bH/6Ww7P33nvneo1jhr81EEIIIUTmkjbimgowX/XzlT7WiUS+67xgISPiHKEeD8Qx1V+sFX5BHb7mMFSfqZ6GwWLAa1RWmzdv7lIN9hSEPVFzHiq3VKe9DYUKN2PGNoMnnNep0rMA0MNzX9XlPCD2XOKdH9cNYY9HPFFHI0QpnucWLVrYcyr+XE8+WxQYM1YafNZ+YWV44SHny2tUuFmY6BdB5gVjIgub60qFXQghhBAi4xY0AiIL0YbdALH36aefmljGE4yNI7ZqHMvAgQPNp0z1Gk8vn2cBIrYDQHTji8a/TOwf7bPxDodBkFH5JDIPkYdFgaoythQWS7IwcPny5WZXwV6CxaMgsAgTDzg2CPbDQkW84owr7COm0k5VF4sDtoqePXvagjxvjyBthMos14lrhNecTGsWcwJCmUq6X8znk0Y4PxZA8hnOj+NybnjbSQjhWIyL8XHMlStX2ufY74gRIyyhg7lgcSULB5OBmxJyrcMPjgssYGQemCvEO2MJf0vBNaHCz7Vg3IhxP5+JviXAm8+Cy3POOceEOFYQ/OF8KxB7YyGEEEIIEUWQZqxatSq4+uqrg/322y/Yfvvtg5122ilo0qRJcMcddwS//fZbZDtOfcaMGbk+/8orrwRHH310sMMOOwS77LKLfXbChAmR90eNGhXsvffe9n7r1q2DyZMn277Wr18f2ebKK68Mqlataq8PGjTIXtuyZUswcODAoE6dOjYu9tGxY8dg0aJF9v7DDz8c7Lrrrvme3+zZs4NOnToF++67b1CxYsWgevXqwSmnnBK89dZbkW04ZqNGjYJ77703qFGjRlCpUqXgjDPOCNatWxfZZuvWrcHgwYODffbZx8bD9i+//HLUsSZOnGjHKV++fNCyZUt77ccffwxOOukku66c35w5c+z11atXB126dAmqVasWZGVlBfvvv39w2WWXBRs2bLD3//rrr6BXr152TXfbbbegd+/etn379u0Tniv75hjxHvPmzbNtFixYEBxxxBF2jgceeGDw9NNPB7Vr1w5Gjx4d2c+nn34aHHPMMXa96tevHzz//PO2D+Yali9fbs8XLlwY+cyyZctsfhgrc83nrrnmmuCff/7Jd444Z/bnzz2V8O9o5syZ9lOkB5rT9ENzml5oPjNnTjek6O93Of4nWm6Lsg7VbSrEsd0Vxf+gek3uNYswqWqnGhY0khpDtT+RTaawULGnnTs2mNLU9EgUHs1p+qE5TS80n5kzpxtT9PdbhlKR9pCnzcJRLCQIaiwqJKMUh7AWQgghRGYjcS2ioBMj3RrJpS7NXHjhhebZ9l0W+QLmiiuucNOnT3fr1683Lzp54bw2depUW+zJ3Sle8hNPPNEWpRY32YNyXPms+AkyhSWrQuBGNnEue3CO27w1uWQZUbopbXO6YkTbkh6CEEKUadJqQWNZAWHo24eHH3Q0TJUtpLCWEBZc0jhnW0CWNNGGxPWxAJNKcufOnd2bb76Z72eJ3qPjo4eFlzx/4YUXLFM7Ozs78hqdO3mNxaUssOS1cL64EEIIIUSqUOW6hEBI08UwTFGykqnckmRR1Og4sru3VbILLeEvuOACSyxBWONxQnBfe+21FtMXD86RGxE8UWFI9CDuj3bseb0mhBBCCFGcqHJdQiCkicULP6pUqWLv0awGARmuPmOB4DUi7oCfPH/55ZetgQv7o6ENgpJIPDKd8RkfeeSR1lUyVtjiP6ZazHZnnHFGlC0k3OKdmDuiDemQyBhpGU80nsePg+hBtiNvGzEb28wnDBncHIPHo48+ai3MaQBDd0r80B9++GFkW6rMNJCZNWuWa9CggZ0nn6f636FDB9uG38k253XGQlxgvNd8V0wiArGHcP4sbAznXhfmfIQQQgghPBLXZRzyqcmPJucZcUrGNqtfEYf4jqmQ023QtwNHuCIuhwwZYoIR64Rv7JJoRS02EfKy8Tcj/BGusdAlEh8z+6d6TvZ2ImjQwn7J645HbP40dg4yuSdNmmT54wjjWIsI51OzZk2zfyCW470GHJPjI+oXLFhg2eWtW7e2XOvCng+CnRXG4YcQQgghMhPZQkoIvMHh1udw44032qMgICDDzWOwdbCQz4MwJi2Dyi82DEQ23SvxOlONpmJMB8lEhEUlreTvvvtuq4Yj4sPjpx287/aI4G/btq37888/rTocy7Jlyyzixje0AQQvjV488+bNcwcffLD9jhCn2h4+rzBYRDgXmgSF9xn7Gosa77vvPquGt2nTxl6bOHGie+2119yDDz5ojXUKcz40A6LxkBBCCCGEKtclRKtWrcz2EX5ceeWVBd4P1oUwiN7rrrvO/etf/zI7BQKYqravXCPEEdQIZfzOU6ZMscpwIvA+U/muVauWiVUvOP3+PFTNPficIWwfya86TfWYa0DHSkRwuBMiLdfD+y8sWGYQ6sTweUgQoeU716iw53PDDTeYX9w/aLcuhBBCiMxElesSguoxloR4lC//v3uecH8f3+473n7CIKypxN555522f1qB46nesmWLvY9Axg6Bt5gUDVq+ky6CbQIxHgaRi+jlgQgn1QNRzXO/P084hN0L53/++SfumPF7I0JpY+6rytwEMN54CzI5h0StyouLgpwPPvCiLEYVQgghRPqgynUpBBELeIU9yUbr0X0QT3THjh3NVoF4xScdBgFL1vPIkSPdokWL7P3Zs2fn2tdnn33m1q5da57u5s2bu/r16+dZjU4WxD7iFR/1toREEqrgXKPwTQs3FiyWFEIIIYQoKqpclxAsgqNyGzUZ223nqlWrZpXapk2bmqjdb7/9TNAOGDAgqf1SFSarGisHFdebb745quKK1/vrr7+2RYykk9D+k/fr1auXa19YQRCj48aNM8vK4sWLU5KBzX5ZLEgyCAsJuRngPPn98ccft23wSqcaqvzdunUzbzXedMbBDQa2mEsuuSTlxxNCCCFE5iFxXUKQ0uG9vB4ELtVieOihh0zwEbPH64jAk08+Od/9jho1yhYhEh+HUO/Xr19UegXWD8Q3VhAW6CHGn3jiCdewYcO4FXQW/7HIkoWMhx12mNlN2rVrV+TzJyYPXzjjpZLNGGns0qxZM7s2fjFjquGGhZsJ/OabNm0yz3pOTk4kBjGVLL6ltS3cTCVU2rkhWjy4dZR1RZRdNKdCCJFelAvCxl4hRJHhRoEEE3zlxSWuiVuUuE4PNKfph+Y0vdB8Zs6cbkzR329VrrcR+JqxPpA93bhx45TsE9sHMXu+mUqqwa5B8xryrUuaVIyFKjyNa9jPtiB7UI4rn1U5pfvMqhC4kU2cyx6c4zZv3baLPEXxUNg5XTGiraZECCFKIVrQmCLhh9D1D+wNNG9hsWBZhkYsCNKygO+sGBbOq1atMnsJ/nLuQjt37mwZ2x6sMam60RFCCCGEAInrFIGYJt2DB90RWZxIo5ayDF+NxMbzlRXItKa1OZneeKo5FxaKxnZ3FEIIIYRIJRLXKYKcY2LveFANpasfzUR++umnuNvTJIUFi1hFEH0sWqRSHAsLG1lsyP5ZAEmXxUQMGjTItklUMScDOyz4x4wZY9VeFhB6yJqmzbivyIctJ8cdd5y1TqeFOGkbnCvV3zAsyETU0smQeLvXX3/djhG2c3BdzjrrLBPu7Kd9+/ZRcYFcm969e9v7fAvA8QqyNIDzZwwsjuS4XF+gCu9vFvidroq0dfffOPgqPdXvSy+91BZ04rk6/vjjbTshhBBCiPyQuC4G6JJIpBxCFXEYDxIratas6Z5++mm3dOlSa+ZCKsdTTz0V2YZW3d27d3eXX365++STT6yFebzGMwhP0jcmT57s3nrrrYTdDOmu+Pbbb0e6H86dO9cSRbBUwPfff28VX0R0Ih599FGLtHv//fctwYT26zStAfaLGK9cubK9P2HCBHfTTTflWkRAExqa2TBWMqdpIEPl3zemIaYPocuNBeMlog9veTK8++67dp6dOnWyOYjXlAawiPTp08duXPw3DrwGZ555psUfvvzyy9ahkpSUE044wcaRKFaRRRDhhxBCCCEyEy1oTBHkRyMSfWdDKsi85rstxsLqVCqnHirY8+bNM3FNVRduu+02E4DkQXuOPPLIqP38/fff7vzzz7eFkgjRffbZJ+EYaQRD/BzbEvH35ptvWuazryojsvl8os6RgHCnQg7E+I0fP95sMLRVR2QjztmP77w4dOhQe88zbdo0u7GgOu47Hz788MNWUeZzxA1SUael+Omnn27v33///WbtSAaa5yCSGVdeUM1mvhDffqzANZw/f76Ja991kfhBrtH06dPtRieW4cOHR82lEEIIITIXVa5TRKtWrayLIg/EGdXZNm3auG+++SbhZ+655x4TudgPEHpUemkvDog7FuRRMc2La6+91qrECOWwsB42bJjt0z/YLwK2UaNGJmKphNMgBrGI2KbaTiWbqm9exFbFuYnwXRs///xzt++++0aJ1SZNmkRtj73iyy+/tMq1HxvWEDK3EeYsPKSKfNRRR0U+gwAmjzoZsJhQ5aYqXhgYH9eCbxzC12/58uU2vnhwI8C4/QPbixBCCCEyE1WuUwRWiXDFl8osi+gmTpxoFehYnnzySfNAY4HAG4zYvOOOO0wog/cJ5wdVYZrAUNk977zzIq/TUdFXwKFGjRr2E8sH4pqqLEIaYUszFyq2iGsq5XkRm61M9TncATI/EK7cUEyZMiVh2/ei8MADD5hHmxsbMixJCikIjI8bBm+VCZNocSfX0le5hRBCCJHZSFwXE4hOLCF//PFH3PfxGtNF8aqrroq8Fq6MIrbr1Kljlguq4omgWyKtzs8991xrGX722Wfb64hmHrEgqPEyUw3G5+wFNwKdmLq8/Nb5waJMqrY//PCDq169ur32wQcfRG2DfxlrCKkdiQLaEbfcZHhhjPXFe5+Tue58A8C1Jxz+xRdfTFiNp3Lv/efh8dGWnuvD9RdCCCGEKAiyhaQIFrUhynh8+umntsCQKijCNx74lT/88EOrOCNqb7755lxClCQOKtu0Hv/iiy/cggUL3Lhx4+L6jB977DF30UUXmS84LxCs+K7xg3shzU8qyYjagw46qNDXgCr6AQcc4Lp27WqJHdxADBgwwN7z/mqq6yyixL6BdQO7BVViUkhWrlxp2+Axp005PmfSR7gBKUjjF46FT7tLly4msONVoQHxzPGx8vz88882hyeeeKJ9k8DCzFdffdVSTFgkycJM5ksIIYQQIi9UuU4RxNkhTn3VuX79+pYEkqgSfMUVV5jXmcV3iMFzzjnHRCQJFR5EKl7k0aNHm4UEUXrGGWfE3R+vY8+44IILrGrrFwPGUqVKFWusQnWZMXrBzWfz81vnB5VzBDExdiy83H///c3qwg0G0XxAkgj+8H79+tkYEfp4xfGW+0o21hR815w/53LxxRfbDQR+5mThmuJp5/Nt27a1m4lYSBR59tln7ZsBxDsLK4kfxE6CmOZmhShFPORcI1+NT5bFt7Qutvbniwe3VvvzNEFzKoQQ6UW5oCABwkIUEKrXZE6ziJGqdiZAFB9+e24GiktcU5GP9b+LsonmNP3QnKYXms/MmdONKfr7rcq1SCkkdZCuge0FQY3F45hjjskYYS2EEEKIzEbiWqQUbB5YPoj+w8aChxnfeCz4oLFjrF+/vsRbrGPdoasm+dqpJHtQjiufVTml+8yqELiRTZzLHpzjNm/9n49dlG2SndMVI9pu03EJIYQoHBm1oDG2nXdZhAV4JIMQrYePmS6PLA5k4V+qBec111yTSxDjZc5rcSGLCFmgiVecBYp0WkzUpTI/WHDoW5OHHyx2FEIIIYQojahyXYr9QLGeWl4jkYPIOxbisYASAcsiyIKkaZQlaK9+2WWXRb3GglEhhBBCiNJIRlWu82Px4sXWfATPMMkQJG8Q0eYh5o6kDRq8UI3F8kCrc1/VpRshzWSwOeAzDndnfO655yxDmWozKRq0yya/2UNF9r777rPcavZB2/BYlixZYlnY9957r2vatKmrXbu2HYcmNTwHouPYF01qyNHmeNnZ2dYgJgzPGS/NTxDp/fv3j4yHCj/vjx07NlItZr8+b5vEEV5jOyBphBbgtHDn2tAFMjYSkIUDxPzxPvthf8mAkCatI/zg+gAZ1ZdccknkuNx0MOYwnBMxf8wJc4ZlhRSSvL7BIJKPdBZSTDgW3SITxfkJIYQQQoSRuP4/qPwef/zx7tBDD7U8Y6L1iKvzXQ6JhiMuj1g4cqwRW0TJEbaCgEOsEWVHvvO8efOsrbjPdibPGbsEi/uWLl1qXQSxS8QKaHKtiZyjNTnHidfBkGg5hGts85NY+vbta5F2xP2R20wc3tq1a+2977//3lbIEpdHu29E/YMPPhjpJIlA5TNUjDlvHrQ1f+aZZyJtznnNC1mE9eTJky1bmhsAWrKff/75EUFPYxmuFWMgU5qoPsR8UUHUY4sh8pDrOnDgQHfjjTe6p556KrLN7bffbhnexOyRXMJKYOIC8+Lqq6+2OeQGhfk888wzreEOWeOJxDj7DT+EEEIIkZnIFvJ/jB8/3oT1sGHDIheHToaISjzENIRBRCMSqRgDVWxYt26dxbacdtppkVQMWop7qFIjJqmYApXrW2+91dp0Dxo0KLIdXmqylRNBJZWGMnyOfR5xxBFWBaYxC/uMFYjkOAPimZsFBDSfpfLNeXHO3ACQd71q1Sqr6iJQiaGheyGZ1FSKPb7jI90V/SJEhCXX7PXXXzdB7s+PdurcRHDDwfG5Ln5hIxVmbiAQvvnBmHwjGg82mObNm5tthuvgoYKNKEZc+5simu7ccMMNdtPi55kqeiJYiIkQ56dvGU8Vm+vH6+F/Hx5uLsLjEEIIIUTmInH9f1DBnTNnjllCYsGKcfLJJ1ujEwR169at7TmNW7BIIDqxSPA6nmjsIog731SGfVM1DVeqqTyz6O/33383EQuI5fzo3r27VcGpnL/33ntWtUXwzZo1y47t8ULXJnm77WzfVNyBn7zvK+uAvYQbCDzctWrVSvofEHF7nEP42LBlyxa7WfHHw1oRJjy+/Crw3n4Svsnw0CiGmyDEMK3mOS7JH8AND98+YH8JN7o5/PDDreodD0Q/cxPbqZKbiEQLMxHvvXv3jjyncs3NixBCCCEyD4nr/8O3Ko9XTUUkI8pee+01a4VNW2wqonTxe//9961iSlUTby8VzmnTplm1le3xQrNvKpvxuib6zoXgvcTJ+JAZKw+sHIh6fsYK3G0B5wYvvvhilOgF/NxFhTi/unXrxn0P2wZVZSriiHWuCx0hmZOinA9z/dFHH9nPMPFuvPx5puJchRBCCFH2kbj+P1hsiKeY+DcqvfGg0kuFlwf2CewhNE3xVUsqtTyoZCL2pk6dauKafeNTTiQSi4K3dSD6w1DVpmU3YGdBLGIV8ZYVzhW/uK9eU1lHnOJhBmwhsb5uXoPw6w0aNDBhSeU4Uft0jkdlPXZ8RYUxs2iTtvHhbxk82FtYmPrBBx9ErgVjX7BgQaS6HQvzxzY//vijWU+EEEIIIQpCxolrrAIsqgvD1/3YLSZOnGiLFvElY/XA8kB1dNKkSbbI8Y033jA7CJ5jqqM//fSTCUeypydMmGBJH/h0EdIsfsO+AQhx/NjYLbCSsCgRqwjpJH4RYTIwbjzapJggahG7LBrEFoE3OQx2CbokMr7Ro0dbsxa/SBIxSsOUHj16mOBmvOyXmwTGBtxkcI6kelCx5XpwM4EYf+GFF2xBJAkdCHKqxyxixGpBq3OuMcKX1qH4zK+88kqrLmPxYDEjQp8Fnck2pVmzZk3Ua9ho2Dfnx0LKnJwc+/bgscceMyHN7x7OEU80NzbchPCNA9cibIkJgx0EDztzx5gR28wzc3/IIYe4tm3VyEMIIYQQeRBkEF27dg045djHJZdcYu8vW7Ys6NixY7DbbrsFO+ywQ1C/fv3gmmuuCf75559g6dKlQevWrYM99tgjyMrKCg466KBg3Lhx9rk1a9YEHTp0CPbee++gYsWKQe3atYOBAwcGW7dujRz7lVdeCY4++mjb7y677BI0adIkmDBhQuR9xjFjxow8x//TTz8FPXv2DLKzs4Oddtop2HnnnYODDz44uPPOOyPHWr58ue1r6tSpdgzG06BBg2D27NlR+/rPf/4THHnkkfb+XnvtFfTr1y/466+/Iu9//vnnQdOmTW287I/9wpAhQ2z7cuXK2fUErs+YMWOCevXqBdtvv71dI67V3LlzI/t7/vnng7p169q1a968efDQQw/ZftevX5/wfLmO8ebriiuusPf//PPP4MILLwx23XVXm7Nu3boF/fv3Dxo1ahTZB+d09dVX2zWvUqWKneeZZ54ZnH322ZFtWrZsGfTq1SvyfMuWLTZ/derUsfNhXvl3sWjRoiAZNmzYYOPkZ6phbDNnzrSfIj3QnKYfmtP0QvOZOXO6IUV/v8vxP3mJb1G2oNJM5ZYIvkTWh0yG6jrVfBackthSHLCgEUsKFXwq7KmERkKknfDNQWyTIVE20ZymH5rT9ELzmTlzujFFf78zzhZS0mBHwKedqIkJKSDE62Fd8HF3JQ0WDlqh+y6Q5HGTFR1rrymNNwE08mEBKn5wEj+I4vMt5D2kkXBu+eVfF5TsQTmufNb/kmBSRVaFwI1s4lz24By3eWt8a4soWyQ7pytGyJIkhBBlATWRKQQ0S8FrHO6wSMoEdz/HHXdcLrGMoA4vtMsLFujRoIU7Jy9sUyWyEcWFEbKdO3e2rO9tDdfSd4gMP/BwJwsecq4hDXNYiErUHpnc4RxyIYQQQohUocp1IaCyjJhmkaNvO04XRhqusAiQ/GofsUd2NgsZfXOZ/GCRYrhxS0FhIWKqnT4sXORREtAlcsiQIVGv+VzwZCBvmsWVQgghhBDbAlWuCwEdBsm+pirt4ff27dub1SEcM+dtHmF+/vln6xiISCTxIhxT5yvd2BT4nY6NeH981ZbqM2BxIKWDbGnysWnSEh5PLFRvydompcTvyyd2jBo1yprjsB/EKGkiPr862eo5iSpUg7mpIJWDLpBh5s+fb8kbvE9DG+wgyeC7RIYfYR8UKSkkfLAdnSFvvvlm81KFIZGFhBe+bfCt1/Oq4OPLJmGEueSmolGjRtZyXgghhBAiPySuCwmCmaq0h9+xMeDt9a/TMZBKdqy4RuSyoG7RokVmpif6jRbq8SwiROYhJrGK8EBQAxF6tPomKpD9nHnmme6UU06xCMBE1o4+ffq4hg0bRvbFa/aPoHx5a6u+ZMkS9+ijj7rZs2dbHGGyTJkyxeIG6UBJN0Y6RiJy2Rcg1IkiJD6QGD5uEPx5FBUEM+J/6dKlbuzYsRanSPRgeGyMi+ZAHJtvEWjHnhcIayL+sP9wTYgZPP/88y32MB7c6LAIIvwQQgghRGYicV1IEMzYDfBdk8VMJRZhTbMSX0FG/CK8YsU1C+jI0yZ7GSGK+KSyG88igveaKrOv2pI5TcMWOkLS+pxGJ1hOEKtkTPN6PKjA8lka5Ph9easHixUZI5aS448/3iq9Tz31VNLXgoxsMqHpQEm1l58I0gceeMDep5kO1eAHH3zQxD1Cm8zrZKACzrjDDwSzh06Y3IQwdjpWch3CYyfX+pJLLrFvAKhwcxNAlT4RzBdzQnY4nS+phjNfiGt/PvHEOPPkH2p9LoQQQmQu8lwXEqrUv/32mzUtIdkD4bbHHnuYwEbI4btGZCPOqJaGoRmJBysGlWk6AiYLi/LoIsgxY4UhDXFiW3UjDKnCJoIFfgjEzz77zKqu3DAw/t9//z1ffzPXgMWaCFj80R724RdlUs3mnMOt3ulgmQxU9WkzH4auix5azVN1ZwzcpHDcsG2EBjnhDo7QpEkTq87Hg8ZBnHdsK/ktW7aYrSUedOT0XTqBayiBLYQQQmQmEteFhKozrcKxgCCufetvOjQirGhHzntUgmOJzSemMk1lN1kQkRUqVDCbAz/DeFEdjsnLK6uRSDwqyd26dTP7BJ0Y3377bRPLCMr8xLX3ZmPHwPcdJnZshQGBnqhtPN8MIL6x2VBlZltsMlTRC4s/nxdffNH87GFo8x4PXk/0nhBCCCEyC4nrIoCVguo04jpsc8Aa8vLLL5vVA9FaFLCGUKUOQwWV16h2YwuJRzxBGm9fCHSEPYLUtz4viCWEKjI3FF9//bUJ3Xiw0JHW5OEUlfCiz8LCDQwt2cOVbXKtYxef8u2Cb0UPPE8EvnCEMtYbf8MkhBBCCJEsEtdFFNfdu3e3dIqwEON3FhxS+Y31WxcUvMRUU9944w1LraCSjB0EIYtgRBQjtn/66SfbBvtF27ZtE+6LBipUtam6sxgQEc748SbjWcZHnpeFJB5Ujnv27GmVYxZVYk8hppCbDuwSNGxBAGMbwUJBtfzOO+9Mat9YNNasWRP1GuK3SpUqlrSCCKZaTY411WYa9ITp0aOHHZeEErzZ2EhYAIpdJx5cE3zbeMa56cDHTloL14VvALp27VqgayOEEEKIDKNo3dkzm+XLl1sP+vr160e9vmLFCnu9Xr16uT7D6zNmzIh6bddddw0efvhh+33OnDm2zfr16yPvX3nllUHVqlXt9UGDBtlrW7ZsCQYOHBjUqVMn2H777YO999476NixY7Bo0aKE4/3zzz+DTp06Bbvttpvtyx9z1KhR9vkddtghaN26dTB58uSoMbAdY/QwhkaNGkXte8qUKUHjxo2DihUrBlWqVAlatGgRPPvss5H3582bZ5/hfbZ75pln7BgLFy5MON6WLVvaNrEPxujp27evXZuddtop6Ny5czB69OioscKQIUOCatWq2TYXX3xx0LNnz6Bp06aR97t27Rq0b98+8vyff/4JxowZY/PHtd1jjz3smHPnzg2SYcOGDTZOfqYa5n3mzJn2U6QHmtP0Q3OaXmg+M2dON6To73c5/qekBb4Q2xIWK5KWglWlOGBBI1V8Kt55+d0LA98yvPTSSxbhGOvdF2UTzWn6oTlNLzSfmTOnG1P091u2EJHWYCvB5sKCRxZYPvHEE5aO8tprr5X00IQQQgiRhkhcl2J8d0e8y3l1SJwwYYK79dZb3ffff2/dFsmtLk3QNGbmzJlRCSapBC855xzvvEli4e6UJBQWVLLA8ZlnnnEnnniiK26yB+W48lnJt2pPhqwKgRvZxLnswTlu89ZyKd23KBn8nAohhEgP1EQmBdBkxLcU5+sFGqnQ4RAxV9zwFQaLJ2kDjri+/PLLUyaI82oRnkpY4OivX/hBPndRoVEOleq1a9daJveCBQusyY0QQgghRHGgynWKICWD7oj4eIi3I1UCgUjb7eKEtAyOSULI3nvv7coyiGA6OHp8B0khhBBCiLKCKtcpgng4FsnRQKZDhw5mOwj7eol1owsiVW1EI7F606dPj9oH9gVi9ngfOwgV3bx45JFHIq28iZZDzPvP3HfffdYWnWxrrBCxi/cQ5e3bt7emM5j2zzrrLPfDDz9E9ku83scffxypIvMa/PLLL+7SSy+1bpR8jiY5bBdmxIgRln9NrB3NaJKt4NNd0rdm58GiAjovMk72x1iJ3EOE5wVjvOKKK+wz5GpnZ2e7F154IfI+thBEPHOGpSS26Qyv0QL94osvtnOgwybWGyGEEEKI/JC4LgYWL15sDU4Qth6E9eTJk21x3ZIlSyxHGdvD3Llz7f3vvvvO7ApkTeNNRsD2798/z+N07tw5IjRpWLN69WoT92Q99+rVy/Xp08fGgtCkJTsdI73QR7CuW7fOjs9NAE1g2J/fL59FgLJPHv69M88805rX0CSHCv1hhx3mTjjhBNuXb0CDpQRxStY11fR777230NeSjG9W85LhvXDhQvuGgGvEzUE8OLc2bdpYLvXjjz/uli5damLfd4tkzNxInH322dZGnrHefPPNkZsHD4KbbGyOSft0mgHRSj0e5Hpjzwk/hBBCCJGZyBaSIqiMUln9+++/TWzR7XD8+PH2Hs8RmwjhZs2aRSrNtBl/4IEHrOmMrzT7KirVZsRfXrYSKtxUe4FKMtVeoEELPnBEIdDIhY6IvE5FHKHKvmkogxgHhD9imu6FVIc5l+222y6yT2C8iHjEtW/3zT5ZrEgVHr/3mDFjrFrNA2677TY772Sq1zR58V0i4a233rIGOVT5PSzc5OZh1qxZ5jWPhWMxxk8//dS+BfDX2sOCT24GENTANgjwO+64w66ZB0Hvrx9+9tGjR9vNCfMSCzdOVPqFEEIIIVS5ThGIVirO77//vvmtqRR36tTJ3vvyyy8tEo58ZUSrfyBosT0AYvCoo46K2qcX4p7wZ6+88sqEY2FfxxxzTNRrPOd1/z6i2gtr3/abRBK/TTywf1BJRtCHx4JIL8h5JILuiVxD/2BMHI+OibRQZ3wcj2Mkqlz77pNeWCd7bb744ouo1vB0uvRgi+Emg5uKeNB1kkxM/+BbCCGEEEJkJqpcp4gdd9zRWonDQw89ZNXWBx980Cq4CESgPfc+++wT9TlfAU6GcJRdqpuTJAPngc2DiMBY8ooKTBbEvr+GHuwt2FaokPMe1fozzjjDWsvHI1WLIGMbtCCwsZzEgzksyDwKIYQQIn2RuC4GsDbceOONZsc499xzrQKL+KLaigUkHlRmsTqEwcoRJlZ4JoJ94Tmmgu7hOePw71Nd5eGr11gjWAjot8EvHq7kAv7qNWvWmF2ERX+Jjk31vkuXLgnPoyAwbuwaHTt2jAj8vBZ6UnFeuXKlW7ZsWdzqtb82scdgW+/LFkIIIYQoLLKFFBMs/EOs3XPPPZY4gbWBRYyPPvqoWSjIWx43bpw9B2weWBP69u1rC+emTp2aa5FdsrAPPouPm33iM3722WdtDECSCSkj5513no0DjzJiGOHPIj5APGP3oFr+888/m2+cz2HxIA3l1VdfNZHLws2bbrrJFi/6SjOVe2IJEbiDBg2yBZyF5cADD7SxMw5sKdysJKogA+fQokULs+RQ8eYcWHz5yiuv2Pss1MRzjneb8XH98cb7ayOEEEIIUSQCUWS6du0atG/fPtfrw4cPD/bYY4/g119/Df75559gzJgxQb169YLtt9/eXm/dunUwd+7cyPbPP/98ULdu3SArKyto3rx58NBDDwVM0fr16xMee+HChbbN8uXLo16/9957g/3339+OddBBBwWTJ0+Oev+bb74J2rVrF+y4447BzjvvHJx55pnBmjVrIu//+eefQadOnYLddtvN9v/www/b6xs3bgx69OgR1KhRw/a97777Buedd17w7bffRj47dOjQoFq1asFOO+1k1+b6668PGjVqlPAcGDvH4FzivdeqVatghx12sGONHz8+aNmyZdCrV6/INrVr1w5Gjx4deb527drgoosuCqpWrRpUqlQpyM7ODl544YXI+9OnTw8aNGhg469Vq1Zwxx13RB0zdn/A+AcNGhQkw4YNG+x8+JlqtmzZEsycOdN+ivRAc5p+aE7TC81n5szphhT9/S7H/xRNngshwhDFR0Y3ixtT7Y2nYRB56KSZxPrCRdlEc5p+aE7TC81n5szpxhT9/ZbnuhSCxxj/MxF3BYFFd8TUYdso7WBbueaaa+w8SxvHHXectX4nVrAoZA/KceWzKrtUklUhcCObOJc9OMdt3lrOpSMrRrQt6SEIIYQQhUae65Cg9d0IuYuhk+L111+fdHdBkXqYi3g3GMxVWbiBEEIIIUTmocp1CLr/sRCPrwvo5EfaBgIvr0YuQgghhBBCeFS5DkFcHs1CiKejMko6BokTHhIzevbs6fbcc09XqVIld+yxx1pHw7DVITbvmcorAj0MXQvZBykivs05NoRYyHYmV5qmLd27dzfRXxCI2qPVN2PafffdreV5OMaObpKcD+9zDDoRckMRrgpv2rTJUkXI8WYsdCrENoGlI3xdSNsgw5vtaCITm4XNtalVq5arXLmyxeqtXbvWpQqSQJgLfx6nnXZapKkNkIsd7ubI2JmTzz77zJ6Tmc24fSv5WMgnx4M1ZcqUlI1ZCCGEEOmJxHUCFi9ebDFz5D17sIk888wzFt9GhB25061bt3br1q1L+oIj0IYOHWrVcKrjCE4i82Kh1TYCkZ8cD3FakGg+hDhjQ8DTRpwsZ7obUp33DVgYA+OhWs/7GPljbRhkdfMeGdzcaLAvzj0MwnXevHnuySefdIsWLbIYQo5DDCCQe00zHbYjUo9ultxgpIrffvvNxkkcIDF75Iwj4H1kH/F8YbE/d+5cV61atchr3CBxvWi/HguRiOecc45dJ24y4sHNBdcu/BBCCCFEZiJxHeKFF14wAUpVmhxo2l2TGe0FHCL4jjvucG3atLFmKxMnTrSOgHRiTBayrRGatEenccnAgQPtWLFUqVLF8pfr169vldi2bduacEwWWokjLidNmmT7p3kKIppGNl5UMhZadyNEOQ7HC1feqVoj7Kmgn3DCCS47O9v2EW4uw/547emnn3bNmzd3BxxwgFWxqSTzOowdO9bENjcnnDPVcoR/MiBsw63WecRWkMm0Pv300+1mh28AyNn+5JNPrDEOUGnn959++smtX7/efieP218Hfh555JFWVQ9DRvlVV13lnn/+eZuDRAwfPtwq2/4RbisvhBBCiMxC4joEFVUqq1RasUcggBFuQBWZ6uYxxxwT2Z6Fj02aNHGffvpp0hecBjF8Jkzsc2jYsGFUx0AsGYh9GDZsWJTYRODGQsOVL7/80irXfjusISzQ5FyImfnhhx+ijs3xDj/88Mjzr7/+2s45vA3isV69epHniFjENqI5PCaqw96awfXBKhKGZjTJgA2FOQk/2rVrF7UNFXJE+P7772/ROb57pL8u3BRw7oyJyvuhhx5qYpnnwE8EeJjp06db0x+q9Ym6anq4QeF6+gd2HCGEEEJkJlrQGALfrW8xTvWzUaNGVpWm0pwM2BFiY8ML6pP2xGYY4xH2Nge6OeKl9tSoUSPX52kTjlCO5xPeY489XKrgOIhyLC6x7cMR2UUFD3xs23duGMIRfv/+979d7dq17ZsErgXXCUHt7S9cO7o2UqHGV4+Qpk06dg5v/4nt0IgAx/7CvwO6Vsb65sOwTx5CCCGEEKpc5yGUb7zxRjdgwAD3xx9/mN0B/zX+47Bwxq+LRcSLVqwUWEg8VFrDUPUNL4KE2Of5QRUWwekf222X+x7psMMOs4ouCyfD2/Lw9oXq1atHHZsKdNhPTSUYkR/ehsosbcPDIpTPUVWPPQ7CGLCk8G1AmPfee8+lAhZG8m0A84R1hWNh/YjF+655IK6ZXwQ3Nh9EdvgbCWC+8bs/99xzrkePHikZqxBCCCHSH4nrPGBhHtVYvLdUtbt162YebNIp8O1edtll7vfff49UtrE+4NtFlGOJYDFc7CJEhBrVcLzMiF8W9rEIMK/KaGFg8R2L9kgIwQqxfPlyE5b4nVeuXBkZC35hBCQCFR8ywtSPhQox9hjOGaG5ZMkSO1eEqd8GOwjH6tKli3v22WftOPPnz7f9krIBHJNrhnebc8bbzfNUgDedhJAJEyaYDWb27Nm2uDEW77vmHPCD+9eo7FOZZn5j4dw4bxaxhtNRhBBCCCESIVtIHlARJuFi5MiRJqxHjBhhloMLLrjAKtSIspycHBN4vqL8+OOPmxjFokAldfDgwe7yyy+P7BMhipcZGwL+Z+wdNEVBkKYSRP6bb75p8Xos9mO8ROUxJt/Sk/fWrFljwpibCMbJQsOwvWPUqFFmQ8GjzOdYlIinmEWfHhYucpPQp08f9/3335uob9q0aWQRIL9zPQYNGmQLOIk4pNJ86623Fvk8EfqklCDgsYLwzcDdd9+dy0PNok4Wa3pvOLANVffYbcOwPwQ723Bd7rrrrqTHtviW1sXW/nzx4NZqfy6EEEKUQsoFsSZhsc056aSTzELx2GOPlejV58YBWwWCP5HwxfKCSEdkJutFzzSI4sN2g4WmuMT1qaeeKnGdJmhO0w/NaXqh+cycOd2Yor/fqlxvY7CR3H///ZEK8RNPPGHNS8LNarYV33zzjXv11VfNj4zvGLsGto5zzz03ss3ChQut2QqJIfxjGzJkiL2O3UQIIYQQQkQjcb2NwavM3RKNZLCFYDvA04tVYluDpQJPOBYVvsDAVoHQp3odBq80nmwWdJJAgocb60dpgeg9PNGlzRedPSjHlc+Kzs4uKlkVAjcyd3KjEEIIIUoJEtfbGJrOJGqznSx4tImii+2mWFBodhJOP4kHaSDE7BUntGTfb7/9cr2OPx0PuxBCCCFEWUHiWmwzWDxI5Z6KeTy46aB5TvhGRAghhBCiLKEovjSEhA/SMYiXozpNC2+avXiwgpCcQdIJFhDSM2hPvnr16qjqeIcOHcwSQndI4u66d+8e1RQHnzaWEhY4ciyiCH1L8fBxZs2aZVngNFqJ103SwzFY2OkfLCog0hB/N5ncjJM25flV/qnqX3HFFfYZUk2wu9Da3oMNBxHPeLCUxCaA8BpdMC+++GKLI6xVq5ZF/QkhhBBC5IfEdRpCZZg4OjKdydMmSo4IvdiFlQhnEkqI7EP0xnYpJOMZcctP9oNYDud2E1M4b948i8Ijq5tccEQ6Wdbh49x+++1u0qRJNh6a2hQEbgpYzfvGG2/Y4kr2T0fGRCKdxJM2bdqY3QVLCdnWRCj6eEEsLqShnH322da6najEm2++OVceOYKbqEWOyc0JUYz4zuPBTQYrjMMPIYQQQmQmsoWkIeGFfVRhyaAmq/ree++NvE4FmtQSOhF6oeyTQDzkd5MggjCtX7++a9u2rYlcmucgbsm35qdvv444pzkMr1P59cfhuLSSz4+jjz46yjLCwkk83+HPEhE4Y8YMq4Yz5lioapMZ/umnn1qmte80Ga7qk/WNoAa2QYDTqZFqvQdBj6j2eeCjR4+2mwwWoMZCw5xbbrkl3/MTQgghRPojcZ2GIDARfEToUUX9+++/LZmEKjLNZYCfXlgD1g9amIfBOhFuKMM2VHuBn3iovYANV3Gxd3hIGDnkkEOSGve0adOikkqwtFC5prpMt0dsK5wL7egTVa5pN1+zZs1c4/IgumNjBGl9PmbMGDsff77hMeMTx6YSe308N9xwQ1RXSK45YxdCCCFE5iFxnWaQvEFnRGwMxP3RNfLtt9+2hi9btmyJiOtwaLoXkLH9hOJtg+0CEL0IUWwWYQEOvgOiX5SYbGt3BGndunWjXqMlOxngWFh4j/2dccYZdi7xSNUiyLzOPRa82zyEEEIIISSu0wzELiIQz7C3WDz11FMpPw52DSq9VHObN2/uigu809g1OnbsGBH13EAkgorzypUr3bJly+JWr6mMx8YP8pxtY28ShBBCCCEKisR1GYVuiVggwmDHoLqLz3ncuHG28A/hiLc61SBGyaHu0qWLCXnE9k8//WSebAQu/uxUcOCBB7pnn33WzoXqMV7pRBVkoNtkixYtXKdOncxfzfXAHsNnWQzZp08fSxzBu925c2dbkImvPOxHF0IIIYQoLBLXZRQi7xC0YbB+kMqBqCShAy8wQhP/NSI41bBwkcWSCNbvv//eujY2bdrUbCmpgnMhEo/FjuyfxYX5pXEQtcfiynPOOcf99ttvJrBJDIHDDjvMKvkDBw40gY2PnIWc4cWMqWLxLa3dLrvsktJ9cuNEh08hhBBClE7KBbFGWyFEkUD8k9HNtwvFJa5JM4n1hYuyieY0/dCcpheaz8yZ040p+vutyrXIeHz7dTKtGzdunLLrkT0ox5XP+t8C0lSRVSFwI5ukdJdCCCGESCFqIpMm4HcmIYRugiRXEB3XunXrqMV7+I5nzpzpypL1hTHHe6xZs6akhyeEEEIIkQtVrtMEFvART0cnRZqm/PDDD7a4cO3ata6sQ2fE2K9nCtrpUQghhBBiW6DKdRrwyy+/WDdDFjG2atXK1a5d2zVp0sQWNLZr1y7SqRGItKPy65/Dc889Zwv9KlWqZMKcboM0a/Gw/X333WdtxcmRZpvp06dH2SrYhjboLDxkP9nZ2W7u3LlR41y8eLHtgxzs6tWruwsuuMD9/PPP+Z4fQppKfPjhYwY/+OADd9JJJ9liR3xSpIUsWLAg6vOkhRx77LE2rgYNGliTnfyq+IUdqxBCCCEyG4nrNAAByAOxSIfEeCBCfcIHnQ79c0Q5SSI0a6EN+AMPPOAeeeQRa0AThgg8quMff/yxRfCdffbZ1u0wTN++fS05BO9ys2bNLD7PV865ATj++OMt4eTDDz+0NulU188666winfumTZtc165drVHOe++9Z9F9LFDgdSCLu0OHDtY85/3333cTJkxwN910U577LOhYueYsggg/hBBCCJGZSFynAdttt50JYiwhu+22m7XzvvHGG92iRYsi2+yxxx72k/ep/PrnVKn79+9vApWKNFVgIuoQ2WHOPPNMd+mll1q+Ne8fccQRlqUd5uqrrzYBTqMWKt1Ukh988EF7jyxpxOqwYcNc/fr17feHHnrIzZkzxxq+5AXtzP0NBA/asnsQweeff77tk+Minmnz7qvmdHf86quv3OTJk12jRo2sgh174xBLQcdK1CHn6h9qfS6EEEJkLvJcpwmIWhq3UImmgvvyyy+7kSNHWu51XhnOVKJZ9BgWnFR7//zzTxOpvl06legwPI9tYhPeBsGPAPfVbY6DOA23RvcgfuN1U/RwTjvvvHPkeTg2h4rygAEDbPEj3SIZO+P+9ttvI35txC43FB4sM3lR0LFiv+ndu3fkOZVrCWwhhBAiM5G4TiPwFFN55oGNg0rzoEGD8hTXtBOnen366afH3V+q4DjYRPCFx0Ijl7wgJo+KezyouGM9GTt2rHnNSUpB5LO4c1uNlWPyEEIIIYSQuE5jWLwXXrRHxZfKbhgWMlLdpYthXlAND3d55Hlsh0heoyMksCDyo48+MquIPw6dE1lISVU7VVB1p3U5Pmv47rvvohYe1qtXz16jws3CRPB+80QU11iFEEIIkf7Ic50GULnFe/z444+bz3r58uXu6aefNltI+/btI9shFonnIyN6/fr19hptwPEjU71esmSJ2ThI/cBqEYb94TvGc0w1fP78+RHh7LnnnnvcjBkzLJ2je/fudgxalwPP161bZy3JEbfYK3JyctxFF12US/DHgt2DMYcfdFcCFjA+9thjNm4WLLLYkkQTD1X8Aw44wCrcXBvEuD83EkPiUZSxCiGEECLDof25KNv8+eefQf/+/YPDDjss2HXXXYPKlSsH9erVCwYMGBD8/vvvke1mzZoV1K1bN9huu+2C2rVrR15/5ZVXgqOPPjrYYYcdgl122SVo0qRJMGHChMj7/DO55557gpNOOinIysoK6tSpE0ybNi3y/vLly22bqVOn2mcrVqwYNGjQIJg9e3bUOJctWxZ07Ngx2G233exY9evXD6655prgn3/+iXtec+bMsf3Ge8ybN8+2WbBgQXDEEUcElSpVCg488MDg6aeftnMbPXp0ZD+ffvppcMwxx9i4OObzzz9v++C8w+NfuHBhoccaZsOGDbY/fqaaLVu2BDNnzrSfIj3QnKYfmtP0QvOZOXO6IUV/v8vxPyUt8EXphgovFWki7bZl+/Diguo1qSFffvmlVbVTDQsaSQ3ZsGFDruY3RYWK/UsvvWQ2mPDCTlF20ZymH5rT9ELzmTlzujFFf79lKBVpDzcGJH9gIUFQk+lNXGFxCGshhBBCZDYS1yLtoaFMv379LJ6PTo4nnniiu+uuu0p6WEIIIYRIQySuRb7k5xxioWRpdheRchJOOhFCCCGEKC6UFiKEEEIIIUSKkLgWQgghhBAiRUhcCyGEEEIIkSIkroUQQgghhEgREtdCCCGEEEKkCIlrIYQQQgghUoTEtRBCCCGEEClC4loIIYQQQogUIXEthBBCCCFEipC4FkIIIYQQIkVIXAshhBBCCJEitkvVjoQQ/yMIAvu5cePGlF+Sv/76y/3++++27+23316XPA3QnKYfmtP0QvOZOXO68f/+bvu/44VF4lqIFLNp0yb7ue++++raCiGEEGXw7/iuu+5a6M+XC4oqz4UQUfzzzz9u1apVbuedd3blypWLvH7kkUe6Dz74INfVKsjr3FUj2r/77ju3yy67lPiVTzT2kthnQT+XzPb5baM5Tf28FPazyW6b13aFeS8T/zvNtDktbfOZ7nN6ZCH/fzcVc4okRljXqFHDlS9feOe0KtdCpBj+g6xZs2au1ytUqBD3/5gL+jrwemn4P/m8xrit91nQzyWzfX7baE5TPy+F/Wyy2+a1XWHey8T/TjN1TkvLfKb7nFYo5P/vpmpOi1Kx9mhBoxDbiO7du6fk9dJEcYyxsPss6OeS2T6/bTSnqbnOqfhsstvmtV1h3svE/041pyVPOs9pYf9/tzT9dypbiBBlCL7K4q56w4YNpaaCIoqG5jT90JymF5rP9GNjMf8tVeVaiDJEVlaWGzRokP0U6YHmNP3QnKYXms/0I6uY/5aqci2EEEIIIUSKUOVaCCGEEEKIFCFxLYQQQgghRIqQuBZCCCGEECJFSFwLIYQQQgiRIiSuhRBCCCGESBES10KkCS+88IKrV6+eO/DAA92kSZNKejgiBXTs2NFVqVLFnXHGGbqeaQCtlo877jjXoEEDd8ghh7inn366pIckisgvv/zijjjiCNe4cWOXnZ3tJk6cqGuaJvz++++udu3a7rrrrivwZxXFJ0Qa8Pfff9sf7Dlz5lgw/uGHH+7effddV7Vq1ZIemigC//nPf9ymTZvco48+6qZPn65rWcZZvXq1++GHH0yIrVmzxv47XbZsmdtxxx1LemiikGzdutVt3rzZVa5c2f32228msD/88EP9f28acNNNN7kvv/zS7bvvvu7OO+8s0GdVuRYiDZg/f75r2LCh22effdxOO+3k2rRp41599dWSHpYoIlQ5d955Z13HNGHvvfc2YQ177bWXq1atmlu3bl1JD0sUgQoVKpiwBkR2EAT2EGWbL774wn322Wf2t7QwSFwLUQp488033b///W9Xo0YNV65cOTdz5sxc29xzzz2uTp06rlKlSu6oo44yQe1ZtWqVCWsPv3///ffbbPwi9XMq0ntOP/roI6t6UhUTZXtOsYY0atTI1axZ0/Xt29dumkTZnlOsIMOHDy/0GCSuhSgF8HUi/+fMf/DxmDZtmuvdu7e1a12wYIFt27p1a/fjjz9u87GK5NCcph+pmlOq1V26dHETJkzYRiMXxTmnu+22m/v444/d8uXL3dSpU836I8runD733HPuoIMOskehCYQQpQr+s5wxY0bUa02aNAm6d+8eeb5169agRo0awfDhw+35O++8E3To0CHyfq9evYIpU6Zsw1GLVM+pZ86cOUGnTp10gdNkTv/888+gefPmweTJk7fpeEXx/nfq6datW/D000/rcpfhOe3fv39Qs2bNoHbt2kHVqlWDXXbZJbjlllsKdFxVroUo5WzZssW+Qj7xxBMjr5UvX96ez5s3z543adLELV682Kwgv/76q3v55ZftTlyU3TkV6Ten/K2/8MIL3fHHH+8uuOCCEhytSNWcUqVm0TFs2LDBLAmkNomyO6fYQUj2WbFihS1kvOyyy9zAgQMLdJztUj5yIURK+fnnn82bWb169ajXec6CC9huu+3cXXfd5Vq1auX++ecfd/3112u1ehmfU+D/8Pm6ma858XMS3dasWbMSGLFIxZy+88479pU0MXzeB/rYY4+5gw8+WBe4jM7pN9984y6//PLIQsYePXpoPtPg/3uLisS1EGlCu3bt7CHSh9dff72khyBSyLHHHms3vyJ94FvD//73vyU9DFFM8E1TYZAtRIhSDivPiXuKXSTDc+K8RNlDc5p+aE7TD81p+lFtG/09lbgWopRTsWJFazbxxhtvRF6j+sVzWQTKJprT9ENzmn5oTtOPitvo76lsIUKUAliESCcoD5FOfNW4++67u1q1allsUNeuXa3NLl9Djhkzxny4F110UYmOWyRGc5p+aE7TD81p+vFrafh7mqK0EyFEESBujf8cYx9du3aNbDNu3LigVq1aQcWKFS1K6L333tM1L8VoTtMPzWn6oTlNP+aUgr+n5fif1El1IYQQQgghMhd5roUQQgghhEgREtdCCCGEEEKkCIlrIYQQQgghUoTEtRBCCCGEEClC4loIIYQQQogUIXEthBBCCCFEipC4FkIIIYQQIkVIXAshhBBCCJEiJK6FEEKkDStWrHDlypWzdselhc8++8w1bdrUVapUyTVu3LikhyOEKGYkroUQQqSMCy+80MTtiBEjol6fOXOmvZ6JDBo0yO24447u888/d2+88YYrrZTGGxMhyiIS10IIIVIKFdrbb7/drV+/Pm2u7JYtWwr92a+++sode+yxrnbt2q5q1aopHZcQovQhcS2EECKlnHjiiW6vvfZyw4cPT7jN4MGDc1kkxowZ4+rUqRNVBe/QoYMbNmyYq169utttt93ckCFD3N9//+369u3rdt99d1ezZk338MMPx7ViHH300Sb0s7Oz3dy5c6PeX7x4sWvTpo3baaedbN8XXHCB+/nnnyPvH3fcce7qq69211xzjatWrZpr3bp13PP4559/bEyMIysry87plVdeibxPJfijjz6ybfid8060n5EjR7q6devafmrVquWGDh0aef+TTz5xxx9/vNthhx1MoF9++eXu119/jRovYw3DteMaeri2XMuLL77Y7bzzznaMCRMmRN7fb7/97Oehhx5qY2WfQoiCI3EthBAipVSoUMFE3Lhx49zKlSuLtK/Zs2e7VatWuTfffNONGjXKLBannXaaq1Klinv//ffdlVde6a644opcx0F89+nTxy1cuNA1a9bM/fvf/3Zr166193755RcTqojIDz/80MTwDz/84M4666yofTz66KOuYsWK7p133nH3339/3PGNHTvW3XXXXe7OO+90ixYtMhHerl0798UXX9j7q1evdg0bNrSx8Pt1110Xdz833HCDWWluvvlmt3TpUjd16lQT/fDbb7/ZfjnnDz74wD399NPu9ddfN/FfUBjrEUccYdflqquuct26dTO7CsyfP99+sm/G+uyzzxZ4/0II51wghBBCpIiuXbsG7du3t9+bNm0aXHzxxfb7jBkzgvCfnEGDBgWNGjWK+uzo0aOD2rVrR+2L51u3bo28Vq9evaB58+aR53///Xew4447Bk888YQ9X758uR1nxIgRkW3++uuvoGbNmsHtt99uz2+99dbg5JNPjjr2d999Z5/7/PPP7XnLli2DQw89NN/zrVGjRjB06NCo14488sjgqquuijznPDnfRGzcuDHIysoKJk6cGPf9CRMmBFWqVAl+/fXXyGsvvvhiUL58+WDNmjWR8fbq1Svqc8wD19DDtTz//PMjz//5559gzz33DO67776oa7dw4cJ8z1sIkRhVroUQQhQL+K6p/n766aeF3gdV3/Ll//+fKqq5Bx98cFSVHJvEjz/+GPU5qtWe7bbbzqq1fhwff/yxmzNnjllC/KN+/foRf7Tn8MMPz3NsGzdutKr6McccE/U6zwtyzmy7efNmd8IJJyR8v1GjRrYoMnwMrCS+6pwshxxySOR3rB/Yd2KvnRCiaGxXxM8LIYQQcWnRooXZGbA8hL2/gGAOAgql/5+//vor1z623377qOcIwnivITSTBa8yNhHEfyx777135PewmC1O8FEXlaJcz4JcOyFE/qhyLYQQotjAR/z888+7efPmRb2+xx57uDVr1kQJwlRGwL333nuR31kAyaLCf/3rX/b8sMMOc0uWLLEFfiwgDD8KIqh32WUXV6NGDfNkh+F5gwYNkt7PgQceaAI7UUwf46bajvc6fAwEdb169SLXE5+0Z+vWrbZosyDgL/efFUIUHolrIYQQxQYWjvPOO8/dfffdUa+TRPHTTz9ZQgZWjHvuuce9/PLLKTsu+5sxY4alhnTv3t1iAUnJAJ6vW7fOnXPOObZAkOPn5OS4iy66qMDCkoWTVMCnTZtmFo3+/fvbTUKvXr2S3geJJv369XPXX3+9mzx5so2Hm4MHH3zQ3uf6sU3Xrl1NMGNp6dGjhyWc+EWPLNB88cUX7cE5s1CRhZsFYc899zSR7xd4btiwoUCfF0L8D4lrIYQQxQoxdLHWA6qx9957r4lg/MQkVSRK0ihsxZwH+3777bfdrFmzLFIPfLUZIX3yySfbDQAxdkT9hf3dydCzZ0/Xu3dvSwNhPwhTjkU1uiCQEsI+Bg4caNemc+fOES905cqVTfxzQ3DkkUe6M844w/zZ48ePj3yeGwfEd5cuXVzLli3d/vvv71q1alWgMeBN5ybogQcesGvUvn37An1eCPE/yrGq8f9+F0IIIYQQQhQBVa6FEEIIIYRIERLXQgghhBBCpAiJayGEEEIIISSuhRBCCCGEKF2oci2EEEIIIUSKkLgWQgghhBAiRUhcCyGEEEIIkSIkroUQQgghhEgREtdCCCGEEEKkCIlrIYQQQgghUoTEtRBCCCGEEClC4loIIYQQQgiXGv4faBYfDhI97+4AAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -2562,7 +2864,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary
- Trektellen sometimes exports several sighting submissions that fall in the same `(species, date, start, end)` window as separate rows instead of one merged row. Summing `count` across duplicates was harmless, but summing `duration_h` inflated observed-hours by however many duplicate rows existed (e.g. Common Buzzard 2022 season-hours went from a real ~350h to a spurious ~1700h).
- Fixes the underlying cause: the datetime column was built by concatenating `date + " " + timestamp` into one string series, and `pd.to_datetime` infers a single format across the whole combined series — a mix of strings/time objects/NaN from different yearly exports silently turned nearly all of 2022-2025 into `NaT`, so periods never split into hourly windows in the first place. Rebuilt the datetime column explicitly instead.
- Fixed stale raw-data paths and extended the year range to include the 2024-2025 Trektellen exports, which weren't being read at all before.
- Rows with no taxonomy match are passed through unaggregated rather than grouped under a shared `NaN` key, which would otherwise sum together counts of unrelated non-target species that happen to share a time window.

## Test plan
- [x] Re-executed the notebook end-to-end against the real raw data and regenerated `data/count/all_count_processed.csv`
- [x] Confirmed 0 duplicate `(species, date, start, end)` rows remain among real (taxonomy-matched) species
- [x] Confirmed total per-species bird counts are unchanged (aggregation is sum-preserving; verified in isolation)
- [x] Confirmed `duration_h` per season for Common Buzzard and several other species (European Honey-buzzard, Red Kite, Black Kite, Eurasian Sparrowhawk) in 2022-2025 is now comparable to the 2019-2021 baseline
- [x] Confirmed no `start >= end` rows and all of the notebook's built-in overlap/sanity assertions still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)